### PR TITLE
[Docs] Centralize issue reporting in the generator repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,9 @@ that your contributions are licensed under the Apache 2.0 license (see
 
 ## How to submit a bug report
 
-Please ensure to specify the following:
+Please report any issues related to this library in the [swift-openapi-generator](https://github.com/apple/swift-openapi-generator/issues) repository.
+
+Specify the following:
 
 * Commit hash
 * Contextual information (e.g. what you were trying to achieve with swift-openapi-runtime)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Implement a new transport or middleware by providing a type that adopts one of t
 
 You can also publish your transport or middleware as a Swift package to allow others to use it with their generated code.
 
+## Reporting issues
+
+Please report any issues related to this library in the [swift-openapi-generator](https://github.com/apple/swift-openapi-generator/issues) repository.
+
 ## Documentation
 
 To learn more, check out the full [documentation][2].

--- a/Sources/OpenAPIRuntime/Documentation.docc/Documentation.md
+++ b/Sources/OpenAPIRuntime/Documentation.docc/Documentation.md
@@ -45,6 +45,10 @@ Implement a new transport or middleware by providing a type that adopts one of t
 
 You can also publish your transport or middleware as a Swift package to allow others to use it with their generated code.
 
+### Reporting issues
+
+Please report any issues related to this library in the [swift-openapi-generator](https://github.com/apple/swift-openapi-generator/issues) repository.
+
 ## Topics
 
 ### Essentials


### PR DESCRIPTION
### Motivation

We are trying out a model where all our generator-related repositories report issues in the generator repo, instead of tracking issues per-repository.

### Modifications

Updated guidance about where to report issues.

### Result

Documentation is updated, hopefully folks will understand why this repo has Issues disabled now.

### Test Plan

Previewed locally.
