### PR TITLE
[Docs] Recommend .upToNextMinor before we tag 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Add the package dependency in your `Package.swift`:
 ),
 ```
 
-and in your target, add `OpenAPIRuntime` to your dependencies:
+Note that this repository does not have a 1.0 tag yet, so the API is not stable.
+
+Next, in your target, add `OpenAPIRuntime` to your dependencies:
 
 ```swift
 .target(name: "MyTarget", dependencies: [

--- a/Sources/OpenAPIRuntime/Documentation.docc/Documentation.md
+++ b/Sources/OpenAPIRuntime/Documentation.docc/Documentation.md
@@ -21,7 +21,9 @@ Add the package dependency in your `Package.swift`:
 ),
 ```
 
-and in your target, add `OpenAPIRuntime` to your dependencies:
+Note that this repository does not have a 1.0 tag yet, so the API is not stable.
+
+Next, in your target, add `OpenAPIRuntime` to your dependencies:
 
 ```swift
 .target(name: "MyTarget", dependencies: [


### PR DESCRIPTION
### Motivation

In our detailed docs, we do recommend adopters use `.upToNextMinor(from: "...")` before we tag 1.0, but our README and getting started docs still used `from` (aka `.upToNextMajor`).

### Modifications

Updated the docs to use `.upToNextMinor`

### Result

Now adopters should use that recommendation and only upgrade between minor versions manually.

### Test Plan

Previewed locally, looks good.
