### PR TITLE
Rename _StringParameterConvertible to _StringConvertible

### DIFF
--- a/Sources/OpenAPIRuntime/Base/_AutoLosslessStringConvertible.swift
+++ b/Sources/OpenAPIRuntime/Base/_AutoLosslessStringConvertible.swift
@@ -20,7 +20,7 @@
 /// Cannot be marked as SPI, as it's added on public types, but should be
 /// considered an internal implementation detail of the generator.
 public protocol _AutoLosslessStringConvertible:
-    RawRepresentable, LosslessStringConvertible, _StringParameterConvertible
+    RawRepresentable, LosslessStringConvertible, _StringConvertible
 where RawValue == String {}
 
 extension _AutoLosslessStringConvertible {

--- a/Sources/OpenAPIRuntime/Base/_StringConvertible.swift
+++ b/Sources/OpenAPIRuntime/Base/_StringConvertible.swift
@@ -13,17 +13,17 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 
-/// This marker protocol represents types used in parameters
-/// (headers, path parameters, query items, ...).
+/// This marker protocol represents types that are representable as a string,
+/// usable in headers, path parameters, query items, and text bodies.
 ///
 /// Cannot be marked as SPI, as it's added on public types, but should be
 /// considered an internal implementation detail of the generator.
-public protocol _StringParameterConvertible: LosslessStringConvertible {}
+public protocol _StringConvertible: LosslessStringConvertible {}
 
-extension String: _StringParameterConvertible {}
-extension Bool: _StringParameterConvertible {}
-extension Int: _StringParameterConvertible {}
-extension Int64: _StringParameterConvertible {}
-extension Int32: _StringParameterConvertible {}
-extension Float: _StringParameterConvertible {}
-extension Double: _StringParameterConvertible {}
+extension String: _StringConvertible {}
+extension Bool: _StringConvertible {}
+extension Int: _StringConvertible {}
+extension Int64: _StringConvertible {}
+extension Int32: _StringConvertible {}
+extension Float: _StringConvertible {}
+extension Double: _StringConvertible {}

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Client.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Client.swift
@@ -15,14 +15,14 @@ import Foundation
 
 extension Converter {
 
-    // MARK: Query - _StringParameterConvertible
+    // MARK: Query - _StringConvertible
 
     /// Adds a query item with a string-convertible value to the request.
     /// - Parameters:
     ///   - request: Request to add the query item.
     ///   - name: Query item name.
     ///   - value: Query item string-convertible value.
-    public func queryAdd<T: _StringParameterConvertible>(
+    public func queryAdd<T: _StringConvertible>(
         in request: inout Request,
         name: String,
         value: T?
@@ -57,14 +57,14 @@ extension Converter {
         }
     }
 
-    // MARK: Query - Array of _StringParameterConvertible
+    // MARK: Query - Array of _StringConvertible
 
     /// Adds a query item with a list of string-convertible values to the request.
     /// - Parameters:
     ///   - request: Request to add the query item.
     ///   - name: Query item name.
     ///   - value: Query item string-convertible values.
-    public func queryAdd<T: _StringParameterConvertible>(
+    public func queryAdd<T: _StringConvertible>(
         in request: inout Request,
         name: String,
         value: [T]?
@@ -91,7 +91,7 @@ extension Converter {
         transforming transform: (T) -> C
     ) throws -> C {
         let decoded: T
-        if let myType = T.self as? _StringParameterConvertible.Type {
+        if let myType = T.self as? _StringConvertible.Type {
             guard
                 let stringValue = String(data: data, encoding: .utf8),
                 let decodedValue = myType.init(stringValue)
@@ -139,7 +139,7 @@ extension Converter {
     ) throws -> Data {
         let body = transform(value)
         headerFields.add(name: "content-type", value: body.contentType)
-        if let value = value as? _StringParameterConvertible {
+        if let value = value as? _StringConvertible {
             guard let data = value.description.data(using: .utf8) else {
                 throw RuntimeError.failedToEncodePrimitiveBodyIntoData
             }

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Common.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Common.swift
@@ -162,7 +162,7 @@ public extension Converter {
         guard let value else {
             return
         }
-        if let value = value as? _StringParameterConvertible {
+        if let value = value as? _StringConvertible {
             headerFields.add(name: name, value: value.description)
             return
         }
@@ -189,7 +189,7 @@ public extension Converter {
         guard let stringValue = headerFields.firstValue(name: name) else {
             return nil
         }
-        if let myType = T.self as? _StringParameterConvertible.Type {
+        if let myType = T.self as? _StringConvertible.Type {
             return myType.init(stringValue).map { $0 as! T }
         }
         let data = Data(stringValue.utf8)

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
@@ -65,7 +65,7 @@ public extension Converter {
     ///   - name: Path variable name.
     ///   - type: Path variable type.
     /// - Returns: Deserialized path variable value, if present.
-    func pathGetOptional<T: _StringParameterConvertible>(
+    func pathGetOptional<T: _StringConvertible>(
         in pathParameters: [String: String],
         name: String,
         as type: T.Type
@@ -85,7 +85,7 @@ public extension Converter {
     ///   - name: Path variable name.
     ///   - type: Path variable type.
     /// - Returns: Deserialized path variable value.
-    func pathGetRequired<T: _StringParameterConvertible>(
+    func pathGetRequired<T: _StringConvertible>(
         in pathParameters: [String: String],
         name: String,
         as type: T.Type
@@ -111,7 +111,7 @@ public extension Converter {
     ///   - name: Query item name.
     ///   - type: Query item value type.
     /// - Returns: Deserialized query item value, if present.
-    func queryGetOptional<T: _StringParameterConvertible>(
+    func queryGetOptional<T: _StringConvertible>(
         in queryParameters: [URLQueryItem],
         name: String,
         as type: T.Type
@@ -135,7 +135,7 @@ public extension Converter {
     ///   - name: Query item name.
     ///   - type: Query item value type.
     /// - Returns: Deserialized query item value.
-    func queryGetRequired<T: _StringParameterConvertible>(
+    func queryGetRequired<T: _StringConvertible>(
         in queryParameters: [URLQueryItem],
         name: String,
         as type: T.Type
@@ -187,7 +187,7 @@ public extension Converter {
         return try self.configuration.dateTranscoder.decode(dateString)
     }
 
-    // MARK: Query - Array of _StringParameterConvertible
+    // MARK: Query - Array of _StringConvertible
 
     /// Returns an array of deserialized values for all the query items
     /// found under the provided name.
@@ -196,7 +196,7 @@ public extension Converter {
     ///   - name: Query item name.
     ///   - type: Query item value type.
     /// - Returns: Deserialized query item value, if present.
-    func queryGetOptional<T: _StringParameterConvertible>(
+    func queryGetOptional<T: _StringConvertible>(
         in queryParameters: [URLQueryItem],
         name: String,
         as type: [T].Type
@@ -226,7 +226,7 @@ public extension Converter {
     ///   - name: Query item name.
     ///   - type: Query item value type.
     /// - Returns: Deserialized query item value.
-    func queryGetRequired<T: _StringParameterConvertible>(
+    func queryGetRequired<T: _StringConvertible>(
         in queryParameters: [URLQueryItem],
         name: String,
         as type: [T].Type
@@ -263,7 +263,7 @@ public extension Converter {
             return nil
         }
         let decoded: T
-        if let myType = T.self as? _StringParameterConvertible.Type {
+        if let myType = T.self as? _StringConvertible.Type {
             guard
                 let stringValue = String(data: data, encoding: .utf8),
                 let decodedValue = myType.init(stringValue)
@@ -309,7 +309,7 @@ public extension Converter {
         let body = transform(value)
         headerFields.add(name: "content-type", value: body.contentType)
         let bodyValue = body.value
-        if let value = bodyValue as? _StringParameterConvertible {
+        if let value = bodyValue as? _StringConvertible {
             guard let data = value.description.data(using: .utf8) else {
                 throw RuntimeError.failedToEncodePrimitiveBodyIntoData
             }

--- a/Sources/OpenAPIRuntime/Conversion/FoundationExtensions.swift
+++ b/Sources/OpenAPIRuntime/Conversion/FoundationExtensions.swift
@@ -45,7 +45,7 @@ extension URLComponents {
     /// - Parameters:
     ///   - name: Query name.
     ///   - value: Typed value.
-    mutating func addQueryItem<T: _StringParameterConvertible>(
+    mutating func addQueryItem<T: _StringConvertible>(
         name: String,
         value: T?
     ) {
@@ -62,7 +62,7 @@ extension URLComponents {
     /// - Parameters:
     ///   - name: Query name.
     ///   - value: Array of typed values.
-    mutating func addQueryItem<T: _StringParameterConvertible>(
+    mutating func addQueryItem<T: _StringConvertible>(
         name: String,
         value: [T]?
     ) {

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
@@ -145,7 +145,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
         )
     }
 
-    // MARK: [HeaderField] - _StringParameterConvertible
+    // MARK: [HeaderField] - _StringConvertible
 
     func testHeaderAdd_string() throws {
         var headerFields: [HeaderField] = []


### PR DESCRIPTION
### Motivation

As part of reworking https://github.com/apple/swift-openapi-runtime/pull/12, we'll be using the protocol `_StringParameterConvertible` not just for parameters, but also for bodies, so renaming it accordingly to reflect that.

### Modifications

Renamed `_StringParameterConvertible` to `_StringConvertible`.

### Result

The naming is more accurate now.

Compatibility-wise, this isn't affecting the generator, as this protocol is not used directly by generated code, only indirectly through `_AutoLosslessStringConvertible`, so we don't even need to stage this change.

### Test Plan

All tests pass.
