### PR TITLE
[Fix] Fix two regressions in Converter

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/Converter+Common.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Common.swift
@@ -247,7 +247,7 @@ extension Converter {
         in headerFields: [HeaderField],
         name: String,
         as type: T.Type
-    ) throws -> T? {
+    ) throws -> T {
         try getRequiredHeaderField(
             in: headerFields,
             name: name,

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
@@ -268,11 +268,11 @@ public extension Converter {
     }
 
     //    | server | get | request body | binary | data | optional | getOptionalRequestBodyAsBinary |
-    func getOptionalRequestBodyAsBinary(
+    func getOptionalRequestBodyAsBinary<C>(
         _ type: Data.Type,
         from data: Data?,
-        transforming transform: (Data) -> Data
-    ) throws -> Data? {
+        transforming transform: (Data) -> C
+    ) throws -> C? {
         try getOptionalRequestBody(
             type,
             from: data,


### PR DESCRIPTION
### Motivation

Found two regressions with the signature of two of the ~50 converter helper methods:
- optional request body of type data
- required header fields of type JSON

### Modifications

Fixed up these signatures.

### Result

Now a project which has both can build.

### Test Plan

Used a test project for finding and fixing these. We should think about increasing the integration test coverage, and run it on runtime PRs.
