### PR TITLE
Add integration test CI check

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,3 +21,6 @@ ARG swiftformat_version=508.0.0
 RUN git clone --branch $swiftformat_version --depth 1 https://github.com/apple/swift-format $HOME/.tools/swift-format-source
 RUN cd $HOME/.tools/swift-format-source && swift build -c release
 RUN ln -s $HOME/.tools/swift-format-source/.build/release/swift-format $HOME/.tools/swift-format
+
+# jq
+RUN apt-get install -y jq

--- a/scripts/run-integration-test.sh
+++ b/scripts/run-integration-test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftOpenAPIGenerator open source project
+##
+## Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+set -euo pipefail
+
+log() { printf -- "** %s\n" "$*" >&2; }
+error() { printf -- "** ERROR: %s\n" "$*" >&2; }
+fatal() { error "$@"; exit 1; }
+
+log "Checking required executables..."
+SWIFT_BIN=${SWIFT_BIN:-$(command -v swift || xcrun -f swift)} || fatal "SWIFT_BIN unset and no swift on PATH"
+JQ_BIN=${JQ_BIN:-$(command -v jq)} || fatal "JQ_BIN unset and no jq on PATH"
+
+CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$(git -C "${CURRENT_SCRIPT_DIR}" rev-parse --show-toplevel)"
+TMP_DIR=$(mktemp -d "${PWD}/tmp.$(basename "$0").XXXXXXXXXX.noindex")
+
+PACKAGE_PATH=${PACKAGE_PATH:-${REPO_ROOT}}
+
+SWIFT_OPENAPI_GENERATOR_REPO_URL="${SWIFT_OPENAPI_GENERATOR_REPO_URL:-https://github.com/apple/swift-openapi-generator}"
+SWIFT_OPENAPI_GENERATOR_REPO_CLONE_DIR="${TMP_DIR}/$(basename "${SWIFT_OPENAPI_GENERATOR_REPO_URL}")"
+INTEGRATION_TEST_PACKAGE_PATH="${SWIFT_OPENAPI_GENERATOR_REPO_CLONE_DIR}/IntegrationTest"
+
+log "Cloning ${SWIFT_OPENAPI_GENERATOR_REPO_URL} to ${SWIFT_OPENAPI_GENERATOR_REPO_CLONE_DIR}"
+git clone --depth=1 "${SWIFT_OPENAPI_GENERATOR_REPO_URL}" "${SWIFT_OPENAPI_GENERATOR_REPO_CLONE_DIR}"
+
+log "Extracting name for Swift package: ${PACKAGE_PATH}"
+PACKAGE_NAME=$(swift package --package-path "${PACKAGE_PATH}" describe --type json | "${JQ_BIN}" -r .name)
+
+log "Overriding dependency in ${INTEGRATION_TEST_PACKAGE_PATH} on ${PACKAGE_NAME} to use ${PACKAGE_PATH}"
+swift package --package-path "${INTEGRATION_TEST_PACKAGE_PATH}" \
+    edit "${PACKAGE_NAME}" --path "${PACKAGE_PATH}"
+
+log "Building integration test package: ${INTEGRATION_TEST_PACKAGE_PATH}"
+swift build --package-path "${INTEGRATION_TEST_PACKAGE_PATH}"
+
+log "✅ Successfully built integration test package."

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -28,6 +28,7 @@ SCRIPT_PATHS=(
   "${CURRENT_SCRIPT_DIR}/check-license-headers.sh"
   "${CURRENT_SCRIPT_DIR}/run-swift-format.sh"
   "${CURRENT_SCRIPT_DIR}/check-for-docc-warnings.sh"
+  "${CURRENT_SCRIPT_DIR}/run-integration-test.sh"
 )
 
 for SCRIPT_PATH in "${SCRIPT_PATHS[@]}"; do


### PR DESCRIPTION
### Motivation

We want to make sure that we don't unknowingly introduce changes in the runtime
that break the generator, which relies on its SPI.

We have an package in a subdirectory in the generator repo that we can be used
as an integration test to gate changes to the various repos in Swift OpenAPI
project, including the runtime package.

The generator repo also contains a script that can be used to clone the
integration test package and use `swift package edit` to override a dependency
to check it still functions with the proposed changes.

### Modifications

- Bring in the `run-integraton-test.sh` script from the generator repo.
- Run this script as part of the soundness pipeline.

### Result

On each pull request, the integration test package will be built with the
changes proposed in the pull request.

### Test Plan

The CI pipeline for this PR will run the integration test because it's been
added to the soundness script, which is run as part of an existing CI pipeline.

I have also validated this locally:

```console
❯ docker-compose -f docker/docker-compose.yaml run --build
soundness
...
** Running /code/scripts/run-integration-test.sh...
...
** Extracting name for Swift package: /code
** Overriding dependency in /code/tmp.run-integration-test.sh.uyS9Hf8siA.noindex/swift-openapi-generator/IntegrationTest on swift-openapi-runtime to use /code
...
Build complete! (42.53s)
** ✅ Successfully built integration test package.
** ✅ All soundness check(s) passed.
```

### Notes

This PR adds the integration test to the soundness script, but we probably want
to split this out into its own pipeline in the future.
