### PR TITLE
Reduce deployment targets by 3 versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ import PackageDescription
 let package = Package(
     name: "swift-openapi-runtime",
     platforms: [
-        .macOS(.v13), .iOS(.v16), .tvOS(.v16), .watchOS(.v9),
+        .macOS(.v10_15), .iOS(.v12), .tvOS(.v13), .watchOS(.v6),
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ import PackageDescription
 let package = Package(
     name: "swift-openapi-runtime",
     platforms: [
-        .macOS(.v10_15), .iOS(.v12), .tvOS(.v13), .watchOS(.v6),
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6),
     ],
     products: [
         .library(

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Client.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Client.swift
@@ -22,7 +22,7 @@ extension Converter {
     ) throws -> String {
         var renderedString = template
         for parameter in parameters {
-            if #available(iOS 16.0, macOS 13.0, *) {
+            if #available(macOS 13, iOS 16.0, tvOS 16, watchOS 9, *) {
                 renderedString.replace(
                     "{}",
                     with: parameter.description,

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Client.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Client.swift
@@ -22,11 +22,21 @@ extension Converter {
     ) throws -> String {
         var renderedString = template
         for parameter in parameters {
-            renderedString.replace(
-                "{}",
-                with: parameter.description,
-                maxReplacements: 1
-            )
+            if #available(iOS 16.0, macOS 13.0, *) {
+                renderedString.replace(
+                    "{}",
+                    with: parameter.description,
+                    maxReplacements: 1
+                )
+            } else {
+                if let range = renderedString.range(of: "{}") {
+                    renderedString = renderedString.replacingOccurrences(
+                        of: "{}",
+                        with: parameter.description,
+                        range: range
+                    )
+                }
+            }
         }
         return renderedString
     }

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Client.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Client.swift
@@ -22,20 +22,12 @@ extension Converter {
     ) throws -> String {
         var renderedString = template
         for parameter in parameters {
-            if #available(macOS 13, iOS 16.0, tvOS 16, watchOS 9, *) {
-                renderedString.replace(
-                    "{}",
+            if let range = renderedString.range(of: "{}") {
+                renderedString = renderedString.replacingOccurrences(
+                    of: "{}",
                     with: parameter.description,
-                    maxReplacements: 1
+                    range: range
                 )
-            } else {
-                if let range = renderedString.range(of: "{}") {
-                    renderedString = renderedString.replacingOccurrences(
-                        of: "{}",
-                        with: parameter.description,
-                        range: range
-                    )
-                }
             }
         }
         return renderedString


### PR DESCRIPTION
### Motivation

Reduce deployment target by 3 versions to gain more adoption.

### Modifications

- Reduced deployment targets by 3 versions
- Modified `Converter#renderedRequestPath` to support iOS 13

### Result

Deployment target will be reduced by 3 versions.

### Resolves

- Resolves https://github.com/apple/swift-openapi-generator/issues/62

### Related PRs

- Paired with https://github.com/apple/swift-openapi-generator/pull/63
