### PR TITLE
Correct variable name in `ClientMiddleware` reference documentation

### DIFF
--- a/Sources/OpenAPIRuntime/Interface/ClientTransport.swift
+++ b/Sources/OpenAPIRuntime/Interface/ClientTransport.swift
@@ -207,7 +207,7 @@ public protocol ClientTransport: Sendable {
 ///         ) async throws -> Response {
 ///             var request = request
 ///             request.headerFields.append(.init(
-///                 name: "Authorization", value: "Bearer \(token)"
+///                 name: "Authorization", value: "Bearer \(self.bearerToken)"
 ///             ))
 ///             return try await next(request, baseURL)
 ///         }

--- a/Sources/OpenAPIRuntime/Interface/ClientTransport.swift
+++ b/Sources/OpenAPIRuntime/Interface/ClientTransport.swift
@@ -207,7 +207,7 @@ public protocol ClientTransport: Sendable {
 ///         ) async throws -> Response {
 ///             var request = request
 ///             request.headerFields.append(.init(
-///                 name: "Authorization", value: "Bearer \(self.bearerToken)"
+///                 name: "Authorization", value: "Bearer \(bearerToken)"
 ///             ))
 ///             return try await next(request, baseURL)
 ///         }


### PR DESCRIPTION
### Motivation

The example for `ClientMiddleware` doesn't compile

### Modifications

Correct the variable name in `ClientMiddleware`

### Result

The example can now compile
