### PR TITLE
Converter SPI methods for required fields should return non-optional types

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/Converter+Common.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Common.swift
@@ -163,7 +163,7 @@ extension Converter {
         in headerFields: [HeaderField],
         name: String,
         as type: [T].Type
-    ) throws -> [T]? {
+    ) throws -> [T] {
         try getRequiredHeaderFields(
             in: headerFields,
             name: name,
@@ -219,7 +219,7 @@ extension Converter {
         in headerFields: [HeaderField],
         name: String,
         as type: [Date].Type
-    ) throws -> [Date]? {
+    ) throws -> [Date] {
         try getRequiredHeaderFields(
             in: headerFields,
             name: name,

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
@@ -202,7 +202,7 @@ public extension Converter {
         _ type: T.Type,
         from data: Data?,
         transforming transform: (T) -> C
-    ) throws -> C? {
+    ) throws -> C {
         try getRequiredRequestBody(
             type,
             from: data,

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Client.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Client.swift
@@ -283,7 +283,7 @@ final class Test_ClientConverterExtensions: Test_Runtime {
 
     //    | client | get | response body | text | string-convertible | required | getResponseBodyAsText |
     func test_getResponseBodyAsText_stringConvertible() throws {
-        let value = try converter.getResponseBodyAsText(
+        let value: String = try converter.getResponseBodyAsText(
             String.self,
             from: testStringData,
             transforming: { $0 }
@@ -293,7 +293,7 @@ final class Test_ClientConverterExtensions: Test_Runtime {
 
     //    | client | get | response body | text | date | required | getResponseBodyAsText |
     func test_getResponseBodyAsText_date() throws {
-        let value = try converter.getResponseBodyAsText(
+        let value: Date = try converter.getResponseBodyAsText(
             Date.self,
             from: testDateStringData,
             transforming: { $0 }
@@ -303,7 +303,7 @@ final class Test_ClientConverterExtensions: Test_Runtime {
 
     //    | client | get | response body | JSON | codable | required | getResponseBodyAsJSON |
     func test_getResponseBodyAsJSON_codable() throws {
-        let value = try converter.getResponseBodyAsJSON(
+        let value: TestPet = try converter.getResponseBodyAsJSON(
             TestPet.self,
             from: testStructData,
             transforming: { $0 }
@@ -313,7 +313,7 @@ final class Test_ClientConverterExtensions: Test_Runtime {
 
     //    | client | get | response body | binary | data | required | getResponseBodyAsBinary |
     func test_getResponseBodyAsBinary_data() throws {
-        let value = try converter.getResponseBodyAsBinary(
+        let value: Data = try converter.getResponseBodyAsBinary(
             Data.self,
             from: testStringData,
             transforming: { $0 }

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
@@ -179,7 +179,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
         let headerFields: [HeaderField] = [
             .init(name: "foo", value: "bar")
         ]
-        let value = try converter.getOptionalHeaderFieldAsText(
+        let value: String? = try converter.getOptionalHeaderFieldAsText(
             in: headerFields,
             name: "foo",
             as: String.self
@@ -192,7 +192,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
         let headerFields: [HeaderField] = [
             .init(name: "foo", value: "bar")
         ]
-        let value = try converter.getRequiredHeaderFieldAsText(
+        let value: String = try converter.getRequiredHeaderFieldAsText(
             in: headerFields,
             name: "foo",
             as: String.self
@@ -206,7 +206,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
             .init(name: "foo", value: "bar"),
             .init(name: "foo", value: "baz"),
         ]
-        let value = try converter.getOptionalHeaderFieldAsText(
+        let value: [String]? = try converter.getOptionalHeaderFieldAsText(
             in: headerFields,
             name: "foo",
             as: [String].self
@@ -220,7 +220,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
             .init(name: "foo", value: "bar"),
             .init(name: "foo", value: "baz"),
         ]
-        let value = try converter.getRequiredHeaderFieldAsText(
+        let value: [String] = try converter.getRequiredHeaderFieldAsText(
             in: headerFields,
             name: "foo",
             as: [String].self
@@ -233,7 +233,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
         let headerFields: [HeaderField] = [
             .init(name: "foo", value: testDateString)
         ]
-        let value = try converter.getOptionalHeaderFieldAsText(
+        let value: Date? = try converter.getOptionalHeaderFieldAsText(
             in: headerFields,
             name: "foo",
             as: Date.self
@@ -246,7 +246,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
         let headerFields: [HeaderField] = [
             .init(name: "foo", value: testDateString)
         ]
-        let value = try converter.getRequiredHeaderFieldAsText(
+        let value: Date = try converter.getRequiredHeaderFieldAsText(
             in: headerFields,
             name: "foo",
             as: Date.self
@@ -260,7 +260,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
             .init(name: "foo", value: testDateString),
             .init(name: "foo", value: testDateString),
         ]
-        let value = try converter.getOptionalHeaderFieldAsText(
+        let value: [Date]? = try converter.getOptionalHeaderFieldAsText(
             in: headerFields,
             name: "foo",
             as: [Date].self
@@ -274,7 +274,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
             .init(name: "foo", value: testDateString),
             .init(name: "foo", value: testDateString),
         ]
-        let value = try converter.getRequiredHeaderFieldAsText(
+        let value: [Date] = try converter.getRequiredHeaderFieldAsText(
             in: headerFields,
             name: "foo",
             as: [Date].self
@@ -287,7 +287,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
         let headerFields: [HeaderField] = [
             .init(name: "foo", value: testStructString)
         ]
-        let value = try converter.getOptionalHeaderFieldAsJSON(
+        let value: TestPet? = try converter.getOptionalHeaderFieldAsJSON(
             in: headerFields,
             name: "foo",
             as: TestPet.self
@@ -300,7 +300,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
         let headerFields: [HeaderField] = [
             .init(name: "foo", value: testStructString)
         ]
-        let value = try converter.getRequiredHeaderFieldAsJSON(
+        let value: TestPet = try converter.getRequiredHeaderFieldAsJSON(
             in: headerFields,
             name: "foo",
             as: TestPet.self

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
@@ -108,7 +108,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         let path: [String: String] = [
             "foo": "bar"
         ]
-        let value = try converter.getPathParameterAsText(
+        let value: String = try converter.getPathParameterAsText(
             in: path,
             name: "foo",
             as: String.self
@@ -121,7 +121,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         let query: [URLQueryItem] = [
             .init(name: "search", value: "foo")
         ]
-        let value = try converter.getOptionalQueryItemAsText(
+        let value: String? = try converter.getOptionalQueryItemAsText(
             in: query,
             name: "search",
             as: String.self
@@ -134,7 +134,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         let query: [URLQueryItem] = [
             .init(name: "search", value: "foo")
         ]
-        let value = try converter.getRequiredQueryItemAsText(
+        let value: String = try converter.getRequiredQueryItemAsText(
             in: query,
             name: "search",
             as: String.self
@@ -148,7 +148,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
             .init(name: "search", value: "foo"),
             .init(name: "search", value: "bar"),
         ]
-        let value = try converter.getOptionalQueryItemAsText(
+        let value: [String]? = try converter.getOptionalQueryItemAsText(
             in: query,
             name: "search",
             as: [String].self
@@ -162,7 +162,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
             .init(name: "search", value: "foo"),
             .init(name: "search", value: "bar"),
         ]
-        let value = try converter.getRequiredQueryItemAsText(
+        let value: [String] = try converter.getRequiredQueryItemAsText(
             in: query,
             name: "search",
             as: [String].self
@@ -175,7 +175,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         let query: [URLQueryItem] = [
             .init(name: "search", value: testDateString)
         ]
-        let value = try converter.getOptionalQueryItemAsText(
+        let value: Date? = try converter.getOptionalQueryItemAsText(
             in: query,
             name: "search",
             as: Date.self
@@ -188,7 +188,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         let query: [URLQueryItem] = [
             .init(name: "search", value: testDateString)
         ]
-        let value = try converter.getRequiredQueryItemAsText(
+        let value: Date = try converter.getRequiredQueryItemAsText(
             in: query,
             name: "search",
             as: Date.self
@@ -202,7 +202,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
             .init(name: "search", value: testDateString),
             .init(name: "search", value: testDateString),
         ]
-        let value = try converter.getOptionalQueryItemAsText(
+        let value: [Date]? = try converter.getOptionalQueryItemAsText(
             in: query,
             name: "search",
             as: [Date].self
@@ -216,7 +216,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
             .init(name: "search", value: testDateString),
             .init(name: "search", value: testDateString),
         ]
-        let value = try converter.getRequiredQueryItemAsText(
+        let value: [Date] = try converter.getRequiredQueryItemAsText(
             in: query,
             name: "search",
             as: [Date].self
@@ -226,7 +226,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
 
     //    | server | get | request body | text | string-convertible | optional | getOptionalRequestBodyAsText |
     func test_getOptionalRequestBodyAsText_stringConvertible() throws {
-        let body = try converter.getOptionalRequestBodyAsText(
+        let body: String? = try converter.getOptionalRequestBodyAsText(
             String.self,
             from: testStringData,
             transforming: { $0 }
@@ -236,7 +236,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
 
     //    | server | get | request body | text | string-convertible | required | getRequiredRequestBodyAsText |
     func test_getRequiredRequestBodyAsText_stringConvertible() throws {
-        let body = try converter.getRequiredRequestBodyAsText(
+        let body: String = try converter.getRequiredRequestBodyAsText(
             String.self,
             from: testStringData,
             transforming: { $0 }
@@ -246,7 +246,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
 
     //    | server | get | request body | text | date | optional | getOptionalRequestBodyAsText |
     func test_getOptionalRequestBodyAsText_date() throws {
-        let body = try converter.getOptionalRequestBodyAsText(
+        let body: Date? = try converter.getOptionalRequestBodyAsText(
             Date.self,
             from: testDateStringData,
             transforming: { $0 }
@@ -256,7 +256,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
 
     //    | server | get | request body | text | date | required | getRequiredRequestBodyAsText |
     func test_getRequiredRequestBodyAsText_date() throws {
-        let body = try converter.getRequiredRequestBodyAsText(
+        let body: Date = try converter.getRequiredRequestBodyAsText(
             Date.self,
             from: testDateStringData,
             transforming: { $0 }
@@ -266,7 +266,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
 
     //    | server | get | request body | JSON | codable | optional | getOptionalRequestBodyAsJSON |
     func test_getOptionalRequestBodyAsJSON_codable() throws {
-        let body = try converter.getOptionalRequestBodyAsJSON(
+        let body: TestPet? = try converter.getOptionalRequestBodyAsJSON(
             TestPet.self,
             from: testStructData,
             transforming: { $0 }
@@ -275,7 +275,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
     }
 
     func test_getOptionalRequestBodyAsJSON_codable_string() throws {
-        let body = try converter.getOptionalRequestBodyAsJSON(
+        let body: String? = try converter.getOptionalRequestBodyAsJSON(
             String.self,
             from: testQuotedStringData,
             transforming: { $0 }
@@ -285,7 +285,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
 
     //    | server | get | request body | JSON | codable | required | getRequiredRequestBodyAsJSON |
     func test_getRequiredRequestBodyAsJSON_codable() throws {
-        let body = try converter.getRequiredRequestBodyAsJSON(
+        let body: TestPet = try converter.getRequiredRequestBodyAsJSON(
             TestPet.self,
             from: testStructData,
             transforming: { $0 }
@@ -295,7 +295,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
 
     //    | server | get | request body | binary | data | optional | getOptionalRequestBodyAsBinary |
     func test_getOptionalRequestBodyAsBinary_data() throws {
-        let body = try converter.getOptionalRequestBodyAsBinary(
+        let body: Data? = try converter.getOptionalRequestBodyAsBinary(
             Data.self,
             from: testStringData,
             transforming: { $0 }
@@ -305,7 +305,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
 
     //    | server | get | request body | binary | data | required | getRequiredRequestBodyAsBinary |
     func test_getRequiredRequestBodyAsBinary_data() throws {
-        let body = try converter.getRequiredRequestBodyAsBinary(
+        let body: Data = try converter.getRequiredRequestBodyAsBinary(
             Data.self,
             from: testStringData,
             transforming: { $0 }


### PR DESCRIPTION
 ### Motivation

`getRequiredRequestBodyAsText` currently returns `C?` instead of `C`. As the value should be required an optional in the return is causing issues.

The errors are `Cannot convert value of type 'C?' to specified type` and `Cannot infer contextual base in reference to member 'text'`

 ### Modifications

Change the return type of `getRequiredRequestBodyAsText`

 ### Result

Code using a required requestBody now compiles without errors.
