### PR TITLE
Add check-for-breaking-api-changes.sh script

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/Converter.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter.swift
@@ -35,7 +35,8 @@ public struct Converter: Sendable {
 
     /// Creates a new converter with the behavior specified by the configuration.
     public init(
-        configuration: Configuration
+        configuration: Configuration,
+        i: Int = 1
     ) {
         self.configuration = configuration
 

--- a/Sources/OpenAPIRuntime/Conversion/Converter.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter.swift
@@ -35,8 +35,7 @@ public struct Converter: Sendable {
 
     /// Creates a new converter with the behavior specified by the configuration.
     public init(
-        configuration: Configuration,
-        i: Int = 1
+        configuration: Configuration
     ) {
         self.configuration = configuration
 

--- a/scripts/check-for-breaking-api-changes.sh
+++ b/scripts/check-for-breaking-api-changes.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftOpenAPIGenerator open source project
+##
+## Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -euo pipefail
+
+log() { printf -- "** %s\n" "$*" >&2; }
+error() { printf -- "** ERROR: %s\n" "$*" >&2; }
+fatal() { error "$@"; exit 1; }
+
+CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$(git -C "${CURRENT_SCRIPT_DIR}" rev-parse --show-toplevel)"
+
+log "Checking required environment variables..."
+test -n "${BASELINE_REPO_URL:-}" || fatal "BASELINE_REPO_URL unset"
+test -n "${BASELINE_TREEISH:-}" || fatal "BASELINE_TREEISH unset"
+
+log "Fetching baseline: ${BASELINE_REPO_URL}#${BASELINE_TREEISH}..."
+git -C "${REPO_ROOT}" fetch "${BASELINE_REPO_URL}" "${BASELINE_TREEISH}"
+BASELINE_COMMIT=$(git -C "${REPO_ROOT}" rev-parse FETCH_HEAD)
+
+log "Checking for API changes since ${BASELINE_REPO_URL}#${BASELINE_TREEISH} (${BASELINE_COMMIT})..."
+swift package --package-path "${REPO_ROOT}" diagnose-api-breaking-changes \
+  "${BASELINE_COMMIT}" \
+  && RC=$? || RC=$?
+
+if [ "${RC}" -ne 0 ]; then
+  fatal "❌ Breaking API changes detected."
+  exit "${RC}"
+fi
+log "✅ No breaking API changes detected."


### PR DESCRIPTION
### Motivation

We want to know when we are making breaking changes to our public API.

### Modifications

Add a script that wraps `swift package diagnose-api-breaking-changes` which we'll start to use in CI. 

### Result

A script can be used to validate the current repo state against a baseline repo and treeish for breaking API changes.

### Notes

Running this script produces the following output:

```console
❯ BASELINE_REPO_URL=https://github.com/apple/swift-openapi-runtime BASELINE_TREEISH=main bash scripts/check-for-breaking-api-changes.sh
** Checking required environment variables...
** Fetching baseline: https://github.com/apple/swift-openapi-runtime#main...
From https://github.com/apple/swift-openapi-runtime
 * branch            main       -> FETCH_HEAD
** Checking for API changes since https://github.com/apple/swift-openapi-runtime#main (e81f70f2a8b445224dc6b97d0c31ed0d190e04de)...
Building for debugging...

Build complete! (7.53s)

No breaking changes detected in OpenAPIRuntime
** ✅ No breaking API changes detected.
```

Then making the following local change...

```diff
diff --git a/Sources/OpenAPIRuntime/Conversion/Converter.swift b/Sources/OpenAPIRuntime/Conversion/Converter.swift
index 2aac666..f2abb63 100644
--- a/Sources/OpenAPIRuntime/Conversion/Converter.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter.swift
@@ -35,7 +35,8 @@ public struct Converter: Sendable {

     /// Creates a new converter with the behavior specified by the configuration.
     public init(
-        configuration: Configuration
+        configuration: Configuration,
+        i: Int = 1
     ) {
         self.configuration = configuration
```

...and rerunning the script, gives the following output...

```
...
1 breaking change detected in OpenAPIRuntime:
  💔 API breakage: constructor Converter.init(configuration:) has been removed
** ERROR: ❌ Breaking API changes detected.
```
