### PR TITLE
Better Sendability to avoid warnings when -strict-concurrency = targeted+

### DIFF
--- a/Sources/OpenAPIRuntime/Interface/ClientTransport.swift
+++ b/Sources/OpenAPIRuntime/Interface/ClientTransport.swift
@@ -229,10 +229,11 @@ public protocol ClientMiddleware: Sendable {
     ///   - operationID: The identifier of the OpenAPI operation.
     ///   - next: A closure that calls the next middleware, or the transport.
     /// - Returns: An HTTP response.
+    @preconcurrency
     func intercept(
         _ request: Request,
         baseURL: URL,
         operationID: String,
-        next: (Request, URL) async throws -> Response
+        next: @Sendable (Request, URL) async throws -> Response
     ) async throws -> Response
 }

--- a/Sources/OpenAPIRuntime/Interface/ServerTransport.swift
+++ b/Sources/OpenAPIRuntime/Interface/ServerTransport.swift
@@ -111,10 +111,9 @@ public protocol ServerTransport {
     ///   - path: The URL path components, for example `["pets", ":petId"]`.
     ///   - queryItemNames: The names of query items to be extracted
     ///   from the request URL that matches the provided HTTP operation.
+    @preconcurrency
     func register(
-        _ handler: @Sendable @escaping (
-            Request, ServerRequestMetadata
-        ) async throws -> Response,
+        _ handler: @Sendable @escaping (Request, ServerRequestMetadata) async throws -> Response,
         method: HTTPMethod,
         path: [RouterPathComponent],
         queryItemNames: Set<String>
@@ -215,10 +214,11 @@ public protocol ServerMiddleware: Sendable {
     ///   - operationID: The identifier of the OpenAPI operation.
     ///   - next: A closure that calls the next middleware, or the transport.
     /// - Returns: An HTTP response.
+    @preconcurrency
     func intercept(
         _ request: Request,
         metadata: ServerRequestMetadata,
         operationID: String,
-        next: (Request, ServerRequestMetadata) async throws -> Response
+        next: @Sendable (Request, ServerRequestMetadata) async throws -> Response
     ) async throws -> Response
 }

--- a/Sources/OpenAPIRuntime/Interface/UniversalServer.swift
+++ b/Sources/OpenAPIRuntime/Interface/UniversalServer.swift
@@ -84,14 +84,16 @@ public struct UniversalServer<APIHandler: Sendable>: Sendable {
     ///   - deserializer: Creates an Input value from the provided HTTP request.
     ///   - serializer: Creates an HTTP response from the provided Output value.
     /// - Returns: The HTTP response produced by `serializer`.
+    @preconcurrency
     public func handle<OperationInput, OperationOutput>(
         request: Request,
         with metadata: ServerRequestMetadata,
         forOperation operationID: String,
-        using handlerMethod: @escaping (APIHandler) -> ((OperationInput) async throws -> OperationOutput),
-        deserializer: @escaping (Request, ServerRequestMetadata) throws -> OperationInput,
-        serializer: @escaping (OperationOutput, Request) throws -> Response
+        using handlerMethod: @Sendable @escaping (APIHandler) -> ((OperationInput) async throws -> OperationOutput),
+        deserializer: @Sendable @escaping (Request, ServerRequestMetadata) throws -> OperationInput,
+        serializer: @Sendable @escaping (OperationOutput, Request) throws -> Response
     ) async throws -> Response {
+        @Sendable
         func wrappingErrors<R>(
             work: () async throws -> R,
             mapError: (Error) -> Error
@@ -102,6 +104,7 @@ public struct UniversalServer<APIHandler: Sendable>: Sendable {
                 throw mapError(error)
             }
         }
+        @Sendable
         func makeError(
             input: OperationInput? = nil,
             output: OperationOutput? = nil,
@@ -116,7 +119,7 @@ public struct UniversalServer<APIHandler: Sendable>: Sendable {
                 underlyingError: error
             )
         }
-        var next: (Request, ServerRequestMetadata) async throws -> Response = { _request, _metadata in
+        var next: @Sendable (Request, ServerRequestMetadata) async throws -> Response = { _request, _metadata in
             let input: OperationInput = try await wrappingErrors {
                 try deserializer(_request, _metadata)
             } mapError: { error in


### PR DESCRIPTION
### Motivation

When using `-strict-concurrency=targeted`, `ClientMiddleware` will emit warnings if an actor is conformed to it:
```swift
import OpenAPIRuntime
import Foundation

actor Middleware: ClientMiddleware {
    func intercept(
        _ request: Request,
        baseURL: URL,
        operationID: String,
        /// Need to add `@Sendable` or the warnings don't go away even with this PR. Code-completion won't add it.
        next: @Sendable (Request, URL) async throws -> Response
    ) async throws -> Response {
        try await next(request, baseURL)
    }
}
```
The code above emit the following warning with the current implementation:

> Sendability of function types in instance method 'intercept(_:baseURL:operationID:next:)' does not match requirement in protocol 'ClientMiddleware'

Repro package: https://github.com/MahdiBM/OAPIRClientWarningsRepro

You can change between this PR and the main branch by commenting out the dependency declarations i've already put in the `Package.swift`.
Then observe there are no warnings with this PR, unlike with the main branch.

### Modifications

Generally add more @Sendables everywhere. Also use @preconcurrency on Sendable functions to ease the migration:
Currently we have:
```swift
public protocol ClientMiddleware: Sendable {
    func intercept(
        _ request: Request,
        baseURL: URL,
        operationID: String,
        next: (Request, URL) async throws -> Response
    ) async throws -> Response
}
```
With this PR we'll have:
```swift
public protocol ClientMiddleware: Sendable {
    @preconcurrency
    /// ~~~^ notice `@preconcurrency`
    func intercept(
        _ request: Request,
        baseURL: URL,
        operationID: String,
        next: @Sendable (Request, URL) async throws -> Response
        /// ~~~^ notice `@Sendable`
    ) async throws -> Response
}
```

### Result

No more warnings when using `-strict-concurrency=targeted` then conforming an actor to `ClientMiddleware`.

### Test Plan

Manually tested, and there is a [repro package](https://github.com/MahdiBM/OAPIRClientWarningsRepro) for maintainers to check.

### Considerations

I've gone an step ahead and added `@preconcurrency` too, to the functions with `@Sendable` closure.
I did it for the compiler to emit warnings instead of throwing errors when users pass a non-sendable closure value as the supposedly-sendable closure.
I can remove those if necessary.
