### PR TITLE
Adopt explicit existential any

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,17 @@
 //===----------------------------------------------------------------------===//
 import PackageDescription
 
+// General Swift-settings for all targets.
+var swiftSettings: [SwiftSetting] = []
+
+#if swift(>=5.9)
+swiftSettings.append(
+    // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
+    // Require `any` for existential types.
+    .enableUpcomingFeature("ExistentialAny")
+)
+#endif
+
 let package = Package(
     name: "swift-openapi-runtime",
     platforms: [
@@ -31,11 +42,13 @@ let package = Package(
     targets: [
         .target(
             name: "OpenAPIRuntime",
-            dependencies: []
+            dependencies: [],
+            swiftSettings: swiftSettings
         ),
         .testTarget(
             name: "OpenAPIRuntimeTests",
-            dependencies: ["OpenAPIRuntime"]
+            dependencies: ["OpenAPIRuntime"],
+            swiftSettings: swiftSettings
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -14,13 +14,6 @@
 //===----------------------------------------------------------------------===//
 import PackageDescription
 
-// General Swift-settings for all targets.
-let swiftSettings: [SwiftSetting] = [
-    // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
-    // Require `any` for existential types.
-    .enableUpcomingFeature("ExistentialAny")
-]
-
 let package = Package(
     name: "swift-openapi-runtime",
     platforms: [
@@ -38,13 +31,11 @@ let package = Package(
     targets: [
         .target(
             name: "OpenAPIRuntime",
-            dependencies: [],
-            swiftSettings: swiftSettings
+            dependencies: []
         ),
         .testTarget(
             name: "OpenAPIRuntimeTests",
-            dependencies: ["OpenAPIRuntime"],
-            swiftSettings: swiftSettings
+            dependencies: ["OpenAPIRuntime"]
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,13 @@
 //===----------------------------------------------------------------------===//
 import PackageDescription
 
+// General Swift-settings for all targets.
+let swiftSettings: [SwiftSetting] = [
+    // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
+    // Require `any` for existential types.
+    .enableUpcomingFeature("ExistentialAny")
+]
+
 let package = Package(
     name: "swift-openapi-runtime",
     platforms: [
@@ -31,11 +38,13 @@ let package = Package(
     targets: [
         .target(
             name: "OpenAPIRuntime",
-            dependencies: []
+            dependencies: [],
+            swiftSettings: swiftSettings
         ),
         .testTarget(
             name: "OpenAPIRuntimeTests",
-            dependencies: ["OpenAPIRuntime"]
+            dependencies: ["OpenAPIRuntime"],
+            swiftSettings: swiftSettings
         ),
     ]
 )

--- a/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
+++ b/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
@@ -36,12 +36,12 @@
 public struct OpenAPIValueContainer: Codable, Equatable, Hashable, Sendable {
 
     /// The underlying dynamic value.
-    public var value: Sendable?
+    public var value: (any Sendable)?
 
     /// Creates a new container with the given validated value.
     /// - Parameter value: A value of a JSON-compatible type, such as `String`,
     /// `[Any]`, and `[String: Any]`.
-    init(validatedValue value: Sendable?) {
+    init(validatedValue value: (any Sendable)?) {
         self.value = value
     }
 
@@ -62,7 +62,7 @@ public struct OpenAPIValueContainer: Codable, Equatable, Hashable, Sendable {
     /// - Parameter value: An untyped value.
     /// - Returns: A cast value if supported.
     /// - Throws: When the value is not supported.
-    static func tryCast(_ value: (any Sendable)?) throws -> Sendable? {
+    static func tryCast(_ value: (any Sendable)?) throws -> (any Sendable)? {
         guard let value = value else {
             return nil
         }
@@ -98,7 +98,7 @@ public struct OpenAPIValueContainer: Codable, Equatable, Hashable, Sendable {
 
     // MARK: Decodable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         if container.decodeNil() {
             self.init(validatedValue: nil)
@@ -124,7 +124,7 @@ public struct OpenAPIValueContainer: Codable, Equatable, Hashable, Sendable {
 
     // MARK: Encodable
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         guard let value = value else {
             try container.encodeNil()
@@ -171,7 +171,7 @@ public struct OpenAPIValueContainer: Codable, Equatable, Hashable, Sendable {
             return lhs == rhs
         case let (lhs as String, rhs as String):
             return lhs == rhs
-        case let (lhs as [Sendable?], rhs as [Sendable?]):
+        case let (lhs as [(any Sendable)?], rhs as [(any Sendable)?]):
             guard lhs.count == rhs.count else {
                 return false
             }
@@ -179,7 +179,7 @@ public struct OpenAPIValueContainer: Codable, Equatable, Hashable, Sendable {
                 .allSatisfy { lhs, rhs in
                     OpenAPIValueContainer(validatedValue: lhs) == OpenAPIValueContainer(validatedValue: rhs)
                 }
-        case let (lhs as [String: Sendable?], rhs as [String: Sendable?]):
+        case let (lhs as [String: (any Sendable)?], rhs as [String: (any Sendable)?]):
             guard lhs.count == rhs.count else {
                 return false
             }
@@ -211,11 +211,11 @@ public struct OpenAPIValueContainer: Codable, Equatable, Hashable, Sendable {
             hasher.combine(value)
         case let value as String:
             hasher.combine(value)
-        case let value as [Sendable]:
+        case let value as [any Sendable]:
             for item in value {
                 hasher.combine(OpenAPIValueContainer(validatedValue: item))
             }
-        case let value as [String: Sendable]:
+        case let value as [String: any Sendable]:
             for (key, itemValue) in value {
                 hasher.combine(key)
                 hasher.combine(OpenAPIValueContainer(validatedValue: itemValue))
@@ -281,11 +281,11 @@ extension OpenAPIValueContainer: ExpressibleByFloatLiteral {
 public struct OpenAPIObjectContainer: Codable, Equatable, Hashable, Sendable {
 
     /// The underlying dynamic dictionary value.
-    public var value: [String: Sendable?]
+    public var value: [String: (any Sendable)?]
 
     /// Creates a new container with the given validated dictionary.
     /// - Parameter value: A dictionary value.
-    init(validatedValue value: [String: Sendable?]) {
+    init(validatedValue value: [String: (any Sendable)?]) {
         self.value = value
     }
 
@@ -311,13 +311,13 @@ public struct OpenAPIObjectContainer: Codable, Equatable, Hashable, Sendable {
     /// - Parameter value: A dictionary with untyped values.
     /// - Returns: A cast dictionary if values are supported.
     /// - Throws: If an unsupported value is found.
-    static func tryCast(_ value: [String: Any?]) throws -> [String: Sendable?] {
+    static func tryCast(_ value: [String: Any?]) throws -> [String: (any Sendable)?] {
         return try value.mapValues(OpenAPIValueContainer.tryCast(_:))
     }
 
     // MARK: Decodable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         let item = try container.decode([String: OpenAPIValueContainer].self)
         self.init(validatedValue: item.mapValues(\.value))
@@ -325,7 +325,7 @@ public struct OpenAPIObjectContainer: Codable, Equatable, Hashable, Sendable {
 
     // MARK: Encodable
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(value.mapValues(OpenAPIValueContainer.init(validatedValue:)))
     }
@@ -385,11 +385,11 @@ public struct OpenAPIObjectContainer: Codable, Equatable, Hashable, Sendable {
 public struct OpenAPIArrayContainer: Codable, Equatable, Hashable, Sendable {
 
     /// The underlying dynamic array value.
-    public var value: [Sendable?]
+    public var value: [(any Sendable)?]
 
     /// Creates a new container with the given validated array.
     /// - Parameter value: An array value.
-    init(validatedValue value: [Sendable?]) {
+    init(validatedValue value: [(any Sendable)?]) {
         self.value = value
     }
 
@@ -414,13 +414,13 @@ public struct OpenAPIArrayContainer: Codable, Equatable, Hashable, Sendable {
     /// Returns the specified value cast to an array of supported values.
     /// - Parameter value: An array with untyped values.
     /// - Returns: A cast value if values are supported, nil otherwise.
-    static func tryCast(_ value: [Any?]) throws -> [Sendable?] {
+    static func tryCast(_ value: [Any?]) throws -> [(any Sendable)?] {
         return try value.map(OpenAPIValueContainer.tryCast(_:))
     }
 
     // MARK: Decodable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         let item = try container.decode([OpenAPIValueContainer].self)
         self.init(validatedValue: item.map(\.value))
@@ -428,7 +428,7 @@ public struct OpenAPIArrayContainer: Codable, Equatable, Hashable, Sendable {
 
     // MARK: Encodable
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(value.map(OpenAPIValueContainer.init(validatedValue:)))
     }

--- a/Sources/OpenAPIRuntime/Conversion/CodableExtensions.swift
+++ b/Sources/OpenAPIRuntime/Conversion/CodableExtensions.swift
@@ -53,7 +53,7 @@ extension Decoder {
         guard !unknownKeys.isEmpty else {
             return .init()
         }
-        let keyValuePairs: [(String, Sendable?)] = try unknownKeys.map { key in
+        let keyValuePairs: [(String, (any Sendable)?)] = try unknownKeys.map { key in
             (
                 key.stringValue,
                 try container.decode(

--- a/Sources/OpenAPIRuntime/Conversion/Configuration.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Configuration.swift
@@ -55,7 +55,7 @@ extension DateTranscoder where Self == ISO8601DateTranscoder {
 
 extension JSONEncoder.DateEncodingStrategy {
     /// Encode the `Date` as a custom value encoded using the given ``DateTranscoder``.
-    static func from(dateTranscoder: DateTranscoder) -> Self {
+    static func from(dateTranscoder: any DateTranscoder) -> Self {
         return .custom { date, encoder in
             let dateAsString = try dateTranscoder.encode(date)
             var container = encoder.singleValueContainer()
@@ -66,7 +66,7 @@ extension JSONEncoder.DateEncodingStrategy {
 
 extension JSONDecoder.DateDecodingStrategy {
     /// Decode the `Date` as a custom value decoded by the given ``DateTranscoder``.
-    static func from(dateTranscoder: DateTranscoder) -> Self {
+    static func from(dateTranscoder: any DateTranscoder) -> Self {
         return .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
@@ -79,7 +79,7 @@ extension JSONDecoder.DateDecodingStrategy {
 public struct Configuration: Sendable {
 
     /// The transcoder used when converting between date and string values.
-    public var dateTranscoder: DateTranscoder
+    public var dateTranscoder: any DateTranscoder
 
     /// Creates a new configuration with the specified values.
     ///
@@ -87,7 +87,7 @@ public struct Configuration: Sendable {
     ///   - dateTranscoder: The transcoder to use when converting between date
     ///   and string values.
     public init(
-        dateTranscoder: DateTranscoder = .iso8601
+        dateTranscoder: any DateTranscoder = .iso8601
     ) {
         self.dateTranscoder = dateTranscoder
     }

--- a/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
+++ b/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
@@ -197,7 +197,7 @@ extension Converter {
         guard let value else {
             return
         }
-        if let value = value as? _StringConvertible {
+        if let value = value as? (any _StringConvertible) {
             headerFields.add(name: name, value: value.description)
             return
         }
@@ -223,7 +223,7 @@ extension Converter {
         guard let stringValue = headerFields.firstValue(name: name) else {
             return nil
         }
-        if let myType = T.self as? _StringConvertible.Type {
+        if let myType = T.self as? any _StringConvertible.Type {
             return myType.init(stringValue).map { $0 as! T }
         }
         let data = Data(stringValue.utf8)

--- a/Sources/OpenAPIRuntime/Errors/ClientError.swift
+++ b/Sources/OpenAPIRuntime/Errors/ClientError.swift
@@ -49,7 +49,7 @@ public struct ClientError: Error {
     public var response: Response?
 
     /// The underlying error that caused the operation to fail.
-    public var underlyingError: Error
+    public var underlyingError: any Error
 
     /// Creates a new error.
     /// - Parameters:
@@ -65,7 +65,7 @@ public struct ClientError: Error {
         request: Request? = nil,
         baseURL: URL? = nil,
         response: Response? = nil,
-        underlyingError: Error
+        underlyingError: any Error
     ) {
         self.operationID = operationID
         self.operationInput = operationInput
@@ -78,7 +78,7 @@ public struct ClientError: Error {
     // MARK: Private
 
     fileprivate var underlyingErrorDescription: String {
-        guard let prettyError = underlyingError as? PrettyStringConvertible else {
+        guard let prettyError = underlyingError as? (any PrettyStringConvertible) else {
             return underlyingError.localizedDescription
         }
         return prettyError.prettyDescription

--- a/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
+++ b/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
@@ -38,8 +38,8 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
     case missingRequiredRequestBody
 
     // Transport/Handler
-    case transportFailed(Error)
-    case handlerFailed(Error)
+    case transportFailed(any Error)
+    case handlerFailed(any Error)
 
     // MARK: CustomStringConvertible
 

--- a/Sources/OpenAPIRuntime/Errors/ServerError.swift
+++ b/Sources/OpenAPIRuntime/Errors/ServerError.swift
@@ -35,7 +35,7 @@ public struct ServerError: Error {
     public var operationOutput: (any Sendable)?
 
     /// The underlying error that caused the operation to fail.
-    public var underlyingError: Error
+    public var underlyingError: any Error
 
     /// Creates a new error.
     /// - Parameters:
@@ -52,7 +52,7 @@ public struct ServerError: Error {
         requestMetadata: ServerRequestMetadata,
         operationInput: (any Sendable)? = nil,
         operationOutput: (any Sendable)? = nil,
-        underlyingError: Error
+        underlyingError: (any Error)
     ) {
         self.operationID = operationID
         self.request = request
@@ -65,7 +65,7 @@ public struct ServerError: Error {
     // MARK: Private
 
     fileprivate var underlyingErrorDescription: String {
-        guard let prettyError = underlyingError as? PrettyStringConvertible else {
+        guard let prettyError = underlyingError as? (any PrettyStringConvertible) else {
             return underlyingError.localizedDescription
         }
         return prettyError.prettyDescription

--- a/Sources/OpenAPIRuntime/Interface/UniversalClient.swift
+++ b/Sources/OpenAPIRuntime/Interface/UniversalClient.swift
@@ -34,17 +34,17 @@ public struct UniversalClient: Sendable {
     public let converter: Converter
 
     /// Type capable of sending HTTP requests and receiving HTTP responses.
-    public var transport: ClientTransport
+    public var transport: any ClientTransport
 
     /// Middlewares to be invoked before `transport`.
-    public var middlewares: [ClientMiddleware]
+    public var middlewares: [any ClientMiddleware]
 
     /// Internal initializer that takes an initialized `Converter`.
     internal init(
         serverURL: URL,
         converter: Converter,
-        transport: ClientTransport,
-        middlewares: [ClientMiddleware]
+        transport: any ClientTransport,
+        middlewares: [any ClientMiddleware]
     ) {
         self.serverURL = serverURL
         self.converter = converter
@@ -56,8 +56,8 @@ public struct UniversalClient: Sendable {
     public init(
         serverURL: URL = .defaultOpenAPIServerURL,
         configuration: Configuration = .init(),
-        transport: ClientTransport,
-        middlewares: [ClientMiddleware] = []
+        transport: any ClientTransport,
+        middlewares: [any ClientMiddleware] = []
     ) {
         self.init(
             serverURL: serverURL,
@@ -93,7 +93,7 @@ public struct UniversalClient: Sendable {
         @Sendable
         func wrappingErrors<R>(
             work: () async throws -> R,
-            mapError: (Error) -> Error
+            mapError: (any Error) -> any Error
         ) async throws -> R {
             do {
                 return try await work()
@@ -106,8 +106,8 @@ public struct UniversalClient: Sendable {
             request: Request? = nil,
             baseURL: URL? = nil,
             response: Response? = nil,
-            error: Error
-        ) -> Error {
+            error: any Error
+        ) -> any Error {
             ClientError(
                 operationID: operationID,
                 operationInput: input,

--- a/Sources/OpenAPIRuntime/Interface/UniversalServer.swift
+++ b/Sources/OpenAPIRuntime/Interface/UniversalServer.swift
@@ -36,14 +36,14 @@ public struct UniversalServer<APIHandler: Sendable>: Sendable {
     public var handler: APIHandler
 
     /// Middlewares to be invoked before `api` handles the request.
-    public var middlewares: [ServerMiddleware]
+    public var middlewares: [any ServerMiddleware]
 
     /// Internal initializer that takes an initialized converter.
     internal init(
         serverURL: URL,
         converter: Converter,
         handler: APIHandler,
-        middlewares: [ServerMiddleware]
+        middlewares: [any ServerMiddleware]
     ) {
         self.serverURL = serverURL
         self.converter = converter
@@ -56,7 +56,7 @@ public struct UniversalServer<APIHandler: Sendable>: Sendable {
         serverURL: URL = .defaultOpenAPIServerURL,
         handler: APIHandler,
         configuration: Configuration = .init(),
-        middlewares: [ServerMiddleware] = []
+        middlewares: [any ServerMiddleware] = []
     ) {
         self.init(
             serverURL: serverURL,
@@ -95,7 +95,7 @@ public struct UniversalServer<APIHandler: Sendable>: Sendable {
         @Sendable
         func wrappingErrors<R>(
             work: () async throws -> R,
-            mapError: (Error) -> Error
+            mapError: (any Error) -> any Error
         ) async throws -> R {
             do {
                 return try await work()
@@ -107,8 +107,8 @@ public struct UniversalServer<APIHandler: Sendable>: Sendable {
         func makeError(
             input: OperationInput? = nil,
             output: OperationOutput? = nil,
-            error: Error
-        ) -> Error {
+            error: any Error
+        ) -> any Error {
             ServerError(
                 operationID: operationID,
                 request: request,

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_CodableExtensions.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_CodableExtensions.swift
@@ -35,7 +35,7 @@ final class Test_CodableExtensions: Test_Runtime {
                 case bar
             }
 
-            init(from decoder: Decoder) throws {
+            init(from decoder: any Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
                 self.bar = try container.decode(String.self, forKey: .bar)
                 try decoder.ensureNoAdditionalProperties(
@@ -91,7 +91,7 @@ final class Test_CodableExtensions: Test_Runtime {
                 case bar
             }
 
-            init(from decoder: Decoder) throws {
+            init(from decoder: any Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
                 self.bar = try container.decode(String.self, forKey: .bar)
                 self.additionalProperties =
@@ -142,7 +142,7 @@ final class Test_CodableExtensions: Test_Runtime {
                 case bar
             }
 
-            init(from decoder: Decoder) throws {
+            init(from decoder: any Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
                 self.bar = try container.decode(String.self, forKey: .bar)
                 self.additionalProperties =
@@ -193,7 +193,7 @@ final class Test_CodableExtensions: Test_Runtime {
                 case bar
             }
 
-            func encode(to encoder: Encoder) throws {
+            func encode(to encoder: any Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 try container.encode(bar, forKey: .bar)
                 try encoder.encodeAdditionalProperties(additionalProperties)
@@ -247,7 +247,7 @@ final class Test_CodableExtensions: Test_Runtime {
                 case bar
             }
 
-            func encode(to encoder: Encoder) throws {
+            func encode(to encoder: any Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 try container.encode(bar, forKey: .bar)
                 try encoder.encodeAdditionalProperties(additionalProperties)


### PR DESCRIPTION
### Motivation

As a follow-on to https://github.com/apple/swift-openapi-generator/pull/99, let's also enable explicit existential any in the runtime library.

### Modifications

Enabled the flag in Package.swift (for Swift 5.9 and newer) and updated all the usage sites.

### Result

The codebase is closer to being ready for Swift 6.

### Test Plan

Updated unit tests as well, all is passing locally.
