### PR TITLE
Improved Encoding/Decoding error descriptions

### DIFF
--- a/Sources/OpenAPIRuntime/Errors/CodingErrors.swift
+++ b/Sources/OpenAPIRuntime/Errors/CodingErrors.swift
@@ -18,17 +18,24 @@ extension DecodingError: PrettyStringConvertible {
         let output: String
         switch self {
         case .dataCorrupted(let context):
-            output = "dataCorrupted - \(context.debugDescription)"
+            output = "dataCorrupted - \(context.prettyDescription)"
         case .keyNotFound(let key, let context):
-            output = "keyNotFound \(key) - \(context.debugDescription)"
+            output = "keyNotFound \(key) - \(context.prettyDescription)"
         case .typeMismatch(let type, let context):
-            output = "typeMismatch \(type) - in \(context.debugDescription)"
+            output = "typeMismatch \(type) - \(context.prettyDescription)"
         case .valueNotFound(let type, let context):
-            output = "valueNotFound \(type) - \(context.debugDescription)"
+            output = "valueNotFound \(type) - \(context.prettyDescription)"
         @unknown default:
             output = "unknown: \(localizedDescription)"
         }
         return "DecodingError: \(output)"
+    }
+}
+
+extension DecodingError.Context: PrettyStringConvertible {
+    var prettyDescription: String {
+        let path = codingPath.map(\.description).joined(separator: "/")
+        return "at \(path): \(debugDescription) (underlying error: \(underlyingError?.localizedDescription ?? "<nil>"))"
     }
 }
 
@@ -37,10 +44,17 @@ extension EncodingError: PrettyStringConvertible {
         let output: String
         switch self {
         case .invalidValue(let value, let context):
-            output = "invalidValue \(value) - \(context)"
+            output = "invalidValue \(value) - \(context.prettyDescription)"
         @unknown default:
             output = "unknown: \(localizedDescription)"
         }
         return "EncodingError: \(output)"
+    }
+}
+
+extension EncodingError.Context: PrettyStringConvertible {
+    var prettyDescription: String {
+        let path = codingPath.map(\.description).joined(separator: "/")
+        return "at \(path): \(debugDescription) (underlying error: \(underlyingError?.localizedDescription ?? "<nil>"))"
     }
 }


### PR DESCRIPTION
### Motivation

When an EncodingError/DecodingError is thrown and printed, we used to omit the the coding path and underlying error, which are often crucial in finding e.g. which part of the payload has a missing field.

### Modifications

This PR improves the logging to include the coding path and underlying error in the output.

### Result

Now when e.g. a DecodingError is thrown and printed, the default output has enough information to know which part of the JSON payload is malformed.

### Test Plan

Tested manually, as we don't have unit tests for exact printing strings.
