### PR TITLE
[Runtime] Consistent style for initializing local variables

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/FoundationExtensions.swift
+++ b/Sources/OpenAPIRuntime/Conversion/FoundationExtensions.swift
@@ -28,7 +28,7 @@ extension Data {
 extension Request {
     /// Allows modifying the parsed query parameters of the request.
     mutating func mutateQuery(_ closure: (inout URLComponents) throws -> Void) rethrows {
-        var urlComponents: URLComponents = .init()
+        var urlComponents = URLComponents()
         if let query {
             urlComponents.percentEncodedQuery = query
         }

--- a/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
+++ b/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
@@ -498,7 +498,7 @@ extension Request {
     /// Allows modifying the parsed query parameters of the request.
     @available(*, deprecated)
     mutating func mutatingQuery(_ closure: (inout URLComponents) throws -> Void) rethrows {
-        var urlComponents: URLComponents = .init()
+        var urlComponents = URLComponents()
         if let query {
             urlComponents.percentEncodedQuery = query
         }

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_CodableExtensions.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_CodableExtensions.swift
@@ -21,7 +21,7 @@ final class Test_CodableExtensions: Test_Runtime {
     }
 
     var testEncoder: JSONEncoder {
-        let encoder: JSONEncoder = .init()
+        let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         return encoder
     }
@@ -187,7 +187,7 @@ final class Test_CodableExtensions: Test_Runtime {
 
         struct Foo: Encodable {
             var bar: String
-            var additionalProperties: OpenAPIObjectContainer = .init()
+            var additionalProperties = OpenAPIObjectContainer()
 
             enum CodingKeys: String, CodingKey {
                 case bar

--- a/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
+++ b/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
@@ -37,7 +37,7 @@ class Test_Runtime: XCTestCase {
     }
 
     var testComponents: URLComponents {
-        var components: URLComponents = .init()
+        var components = URLComponents()
         components.path = "/api"
         return components
     }


### PR DESCRIPTION
### Motivation

Move to a consistent style when initializing local variables, always use `let foo = Foo(...)` vs `let foo: Foo = .init(...)`.

### Modifications

Updated all occurrences of the latter to use the former.

### Result

Consistent local variable initialization.

### Test Plan

All tests passed.
