### PR TITLE
[Runtime] Support unexploded query items

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/Converter+Client.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Client.swift
@@ -36,8 +36,8 @@ extension Converter {
     //    | client | set | request query | text | string-convertible | both | setQueryItemAsText |
     public func setQueryItemAsText<T: _StringConvertible>(
         in request: inout Request,
-        style: ParameterStyle? = nil,
-        explode: Bool? = nil,
+        style: ParameterStyle?,
+        explode: Bool?,
         name: String,
         value: T?
     ) throws {
@@ -54,8 +54,8 @@ extension Converter {
     //    | client | set | request query | text | array of string-convertibles | both | setQueryItemAsText |
     public func setQueryItemAsText<T: _StringConvertible>(
         in request: inout Request,
-        style: ParameterStyle? = nil,
-        explode: Bool? = nil,
+        style: ParameterStyle?,
+        explode: Bool?,
         name: String,
         value: [T]?
     ) throws {
@@ -72,8 +72,8 @@ extension Converter {
     //    | client | set | request query | text | date | both | setQueryItemAsText |
     public func setQueryItemAsText(
         in request: inout Request,
-        style: ParameterStyle? = nil,
-        explode: Bool? = nil,
+        style: ParameterStyle?,
+        explode: Bool?,
         name: String,
         value: Date?
     ) throws {
@@ -90,8 +90,8 @@ extension Converter {
     //    | client | set | request query | text | array of dates | both | setQueryItemAsText |
     public func setQueryItemAsText(
         in request: inout Request,
-        style: ParameterStyle? = nil,
-        explode: Bool? = nil,
+        style: ParameterStyle?,
+        explode: Bool?,
         name: String,
         value: [Date]?
     ) throws {

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Client.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Client.swift
@@ -36,11 +36,15 @@ extension Converter {
     //    | client | set | request query | text | string-convertible | both | setQueryItemAsText |
     public func setQueryItemAsText<T: _StringConvertible>(
         in request: inout Request,
+        style: ParameterStyle? = nil,
+        explode: Bool? = nil,
         name: String,
         value: T?
     ) throws {
         try setQueryItem(
             in: &request,
+            style: style,
+            explode: explode,
             name: name,
             value: value,
             convert: convertStringConvertibleToText
@@ -50,11 +54,15 @@ extension Converter {
     //    | client | set | request query | text | array of string-convertibles | both | setQueryItemAsText |
     public func setQueryItemAsText<T: _StringConvertible>(
         in request: inout Request,
+        style: ParameterStyle? = nil,
+        explode: Bool? = nil,
         name: String,
         value: [T]?
     ) throws {
         try setQueryItems(
             in: &request,
+            style: style,
+            explode: explode,
             name: name,
             values: value,
             convert: convertStringConvertibleToText
@@ -64,11 +72,15 @@ extension Converter {
     //    | client | set | request query | text | date | both | setQueryItemAsText |
     public func setQueryItemAsText(
         in request: inout Request,
+        style: ParameterStyle? = nil,
+        explode: Bool? = nil,
         name: String,
         value: Date?
     ) throws {
         try setQueryItem(
             in: &request,
+            style: style,
+            explode: explode,
             name: name,
             value: value,
             convert: convertDateToText
@@ -78,11 +90,15 @@ extension Converter {
     //    | client | set | request query | text | array of dates | both | setQueryItemAsText |
     public func setQueryItemAsText(
         in request: inout Request,
+        style: ParameterStyle? = nil,
+        explode: Bool? = nil,
         name: String,
         value: [Date]?
     ) throws {
         try setQueryItems(
             in: &request,
+            style: style,
+            explode: explode,
             name: name,
             values: value,
             convert: convertDateToText

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
@@ -74,11 +74,15 @@ public extension Converter {
     //    | server | get | request query | text | string-convertible | optional | getOptionalQueryItemAsText |
     func getOptionalQueryItemAsText<T: _StringConvertible>(
         in queryParameters: [URLQueryItem],
+        style: ParameterStyle? = nil,
+        explode: Bool? = nil,
         name: String,
         as type: T.Type
     ) throws -> T? {
         try getOptionalQueryItem(
             in: queryParameters,
+            style: style,
+            explode: explode,
             name: name,
             as: type,
             convert: convertTextToStringConvertible
@@ -88,11 +92,15 @@ public extension Converter {
     //    | server | get | request query | text | string-convertible | required | getRequiredQueryItemAsText |
     func getRequiredQueryItemAsText<T: _StringConvertible>(
         in queryParameters: [URLQueryItem],
+        style: ParameterStyle? = nil,
+        explode: Bool? = nil,
         name: String,
         as type: T.Type
     ) throws -> T {
         try getRequiredQueryItem(
             in: queryParameters,
+            style: style,
+            explode: explode,
             name: name,
             as: type,
             convert: convertTextToStringConvertible
@@ -102,11 +110,15 @@ public extension Converter {
     //    | server | get | request query | text | array of string-convertibles | optional | getOptionalQueryItemAsText |
     func getOptionalQueryItemAsText<T: _StringConvertible>(
         in queryParameters: [URLQueryItem],
+        style: ParameterStyle? = nil,
+        explode: Bool? = nil,
         name: String,
         as type: [T].Type
     ) throws -> [T]? {
         try getOptionalQueryItems(
             in: queryParameters,
+            style: style,
+            explode: explode,
             name: name,
             as: type,
             convert: convertTextToStringConvertible
@@ -116,11 +128,15 @@ public extension Converter {
     //    | server | get | request query | text | array of string-convertibles | required | getRequiredQueryItemAsText |
     func getRequiredQueryItemAsText<T: _StringConvertible>(
         in queryParameters: [URLQueryItem],
+        style: ParameterStyle? = nil,
+        explode: Bool? = nil,
         name: String,
         as type: [T].Type
     ) throws -> [T] {
         try getRequiredQueryItems(
             in: queryParameters,
+            style: style,
+            explode: explode,
             name: name,
             as: type,
             convert: convertTextToStringConvertible
@@ -130,11 +146,15 @@ public extension Converter {
     //    | server | get | request query | text | date | optional | getOptionalQueryItemAsText |
     func getOptionalQueryItemAsText(
         in queryParameters: [URLQueryItem],
+        style: ParameterStyle? = nil,
+        explode: Bool? = nil,
         name: String,
         as type: Date.Type
     ) throws -> Date? {
         try getOptionalQueryItem(
             in: queryParameters,
+            style: style,
+            explode: explode,
             name: name,
             as: type,
             convert: convertTextToDate
@@ -144,11 +164,15 @@ public extension Converter {
     //    | server | get | request query | text | date | required | getRequiredQueryItemAsText |
     func getRequiredQueryItemAsText(
         in queryParameters: [URLQueryItem],
+        style: ParameterStyle? = nil,
+        explode: Bool? = nil,
         name: String,
         as type: Date.Type
     ) throws -> Date {
         try getRequiredQueryItem(
             in: queryParameters,
+            style: style,
+            explode: explode,
             name: name,
             as: type,
             convert: convertTextToDate
@@ -158,11 +182,15 @@ public extension Converter {
     //    | server | get | request query | text | array of dates | optional | getOptionalQueryItemAsText |
     func getOptionalQueryItemAsText(
         in queryParameters: [URLQueryItem],
+        style: ParameterStyle? = nil,
+        explode: Bool? = nil,
         name: String,
         as type: [Date].Type
     ) throws -> [Date]? {
         try getOptionalQueryItems(
             in: queryParameters,
+            style: style,
+            explode: explode,
             name: name,
             as: type,
             convert: convertTextToDate
@@ -172,11 +200,15 @@ public extension Converter {
     //    | server | get | request query | text | array of dates | required | getRequiredQueryItemAsText |
     func getRequiredQueryItemAsText(
         in queryParameters: [URLQueryItem],
+        style: ParameterStyle? = nil,
+        explode: Bool? = nil,
         name: String,
         as type: [Date].Type
     ) throws -> [Date] {
         try getRequiredQueryItems(
             in: queryParameters,
+            style: style,
+            explode: explode,
             name: name,
             as: type,
             convert: convertTextToDate

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
@@ -74,8 +74,8 @@ public extension Converter {
     //    | server | get | request query | text | string-convertible | optional | getOptionalQueryItemAsText |
     func getOptionalQueryItemAsText<T: _StringConvertible>(
         in queryParameters: [URLQueryItem],
-        style: ParameterStyle? = nil,
-        explode: Bool? = nil,
+        style: ParameterStyle?,
+        explode: Bool?,
         name: String,
         as type: T.Type
     ) throws -> T? {
@@ -92,8 +92,8 @@ public extension Converter {
     //    | server | get | request query | text | string-convertible | required | getRequiredQueryItemAsText |
     func getRequiredQueryItemAsText<T: _StringConvertible>(
         in queryParameters: [URLQueryItem],
-        style: ParameterStyle? = nil,
-        explode: Bool? = nil,
+        style: ParameterStyle?,
+        explode: Bool?,
         name: String,
         as type: T.Type
     ) throws -> T {
@@ -110,8 +110,8 @@ public extension Converter {
     //    | server | get | request query | text | array of string-convertibles | optional | getOptionalQueryItemAsText |
     func getOptionalQueryItemAsText<T: _StringConvertible>(
         in queryParameters: [URLQueryItem],
-        style: ParameterStyle? = nil,
-        explode: Bool? = nil,
+        style: ParameterStyle?,
+        explode: Bool?,
         name: String,
         as type: [T].Type
     ) throws -> [T]? {
@@ -128,8 +128,8 @@ public extension Converter {
     //    | server | get | request query | text | array of string-convertibles | required | getRequiredQueryItemAsText |
     func getRequiredQueryItemAsText<T: _StringConvertible>(
         in queryParameters: [URLQueryItem],
-        style: ParameterStyle? = nil,
-        explode: Bool? = nil,
+        style: ParameterStyle?,
+        explode: Bool?,
         name: String,
         as type: [T].Type
     ) throws -> [T] {
@@ -146,8 +146,8 @@ public extension Converter {
     //    | server | get | request query | text | date | optional | getOptionalQueryItemAsText |
     func getOptionalQueryItemAsText(
         in queryParameters: [URLQueryItem],
-        style: ParameterStyle? = nil,
-        explode: Bool? = nil,
+        style: ParameterStyle?,
+        explode: Bool?,
         name: String,
         as type: Date.Type
     ) throws -> Date? {
@@ -164,8 +164,8 @@ public extension Converter {
     //    | server | get | request query | text | date | required | getRequiredQueryItemAsText |
     func getRequiredQueryItemAsText(
         in queryParameters: [URLQueryItem],
-        style: ParameterStyle? = nil,
-        explode: Bool? = nil,
+        style: ParameterStyle?,
+        explode: Bool?,
         name: String,
         as type: Date.Type
     ) throws -> Date {
@@ -182,8 +182,8 @@ public extension Converter {
     //    | server | get | request query | text | array of dates | optional | getOptionalQueryItemAsText |
     func getOptionalQueryItemAsText(
         in queryParameters: [URLQueryItem],
-        style: ParameterStyle? = nil,
-        explode: Bool? = nil,
+        style: ParameterStyle?,
+        explode: Bool?,
         name: String,
         as type: [Date].Type
     ) throws -> [Date]? {
@@ -200,8 +200,8 @@ public extension Converter {
     //    | server | get | request query | text | array of dates | required | getRequiredQueryItemAsText |
     func getRequiredQueryItemAsText(
         in queryParameters: [URLQueryItem],
-        style: ParameterStyle? = nil,
-        explode: Bool? = nil,
+        style: ParameterStyle?,
+        explode: Bool?,
         name: String,
         as type: [Date].Type
     ) throws -> [Date] {

--- a/Sources/OpenAPIRuntime/Conversion/CurrencyExtensions.swift
+++ b/Sources/OpenAPIRuntime/Conversion/CurrencyExtensions.swift
@@ -340,6 +340,9 @@ extension Converter {
         as type: T.Type,
         convert: (String) throws -> T
     ) throws -> T? {
+        // Even though the return value isn't used, the validation
+        // in the method is important for consistently handling
+        // style+explode combinations in all the helper functions.
         let (_, _) = try ParameterStyle.resolvedQueryStyleAndExplode(
             name: name,
             style: style,

--- a/Sources/OpenAPIRuntime/Conversion/FoundationExtensions.swift
+++ b/Sources/OpenAPIRuntime/Conversion/FoundationExtensions.swift
@@ -36,10 +36,21 @@ extension Request {
         query = urlComponents.percentEncodedQuery
     }
 
-    /// Allows modifying the parsed query parameters of the request.
-    mutating func addQueryItem(name: String, value: String) {
+    /// Adds the provided name and value to the URL's query.
+    /// - Parameters:
+    ///   - name: The name of the query item.
+    ///   - value: The value of the query item.
+    ///   - explode: A Boolean value indicating whether query items with the
+    ///   same name should be provided as separate key-value pairs (`true`) or
+    ///   if all the values for one key should be concatenated with a comma
+    ///   and provided as a single key-value pair (`false`).
+    mutating func addQueryItem(name: String, value: String, explode: Bool) {
         mutateQuery { urlComponents in
-            urlComponents.addStringQueryItem(name: name, value: value)
+            urlComponents.addStringQueryItem(
+                name: name,
+                value: value,
+                explode: explode
+            )
         }
     }
 }
@@ -47,13 +58,46 @@ extension Request {
 extension URLComponents {
 
     /// Adds the provided name and value to the URL's query.
+    /// - Parameters:
+    ///   - name: The name of the query item.
+    ///   - value: The value of the query item.
+    ///   - explode: A Boolean value indicating whether query items with the
+    ///   same name should be provided as separate key-value pairs (`true`) or
+    ///   if all the values for one key should be concatenated with a comma
+    ///   and provided as a single key-value pair (`false`).
     mutating func addStringQueryItem(
         name: String,
-        value: String
+        value: String,
+        explode: Bool
     ) {
-        queryItems =
-            (queryItems ?? []) + [
-                .init(name: name, value: value)
-            ]
+        if explode {
+            queryItems =
+                (queryItems ?? []) + [
+                    .init(name: name, value: value)
+                ]
+            return
+        }
+        // When explode is false, we need to collect all the potential existing
+        // values from the array with the same name, add the new one, and
+        // concatenate them with a comma.
+        let originalQueryItems = queryItems ?? []
+        struct GroupedQueryItems {
+            var matchingValues: [String] = []
+            var otherItems: [URLQueryItem] = []
+        }
+        let groups =
+            originalQueryItems
+            .reduce(into: GroupedQueryItems()) { partialResult, item in
+                if item.name == name {
+                    partialResult.matchingValues.append(item.value ?? "")
+                } else {
+                    partialResult.otherItems.append(item)
+                }
+            }
+        let newItem = URLQueryItem(
+            name: name,
+            value: (groups.matchingValues + [value]).joined(separator: ",")
+        )
+        queryItems = groups.otherItems + [newItem]
     }
 }

--- a/Sources/OpenAPIRuntime/Conversion/ParameterStyles.swift
+++ b/Sources/OpenAPIRuntime/Conversion/ParameterStyles.swift
@@ -16,7 +16,7 @@
 ///
 /// Details: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#fixed-fields-10
 @_spi(Generated)
-public enum ParameterStyle {
+public enum ParameterStyle: Sendable {
 
     /// The form style.
     ///

--- a/Sources/OpenAPIRuntime/Conversion/ParameterStyles.swift
+++ b/Sources/OpenAPIRuntime/Conversion/ParameterStyles.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// The serialization style used by a parameter.
+///
+/// Details: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#fixed-fields-10
+@_spi(Generated)
+public enum ParameterStyle {
+
+    /// The form style.
+    ///
+    /// Details: https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.8
+    case form
+
+    /// The simple style.
+    ///
+    /// Details: https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.2
+    case simple
+}
+
+extension ParameterStyle {
+
+    /// The default style for path parameters.
+    static let defaultForPathParameters: Self = .simple
+
+    /// The default style for query items.
+    static let defaultForQueryItems: Self = .form
+
+    /// The default style for query items.
+    static let defaultForHeaderFields: Self = .simple
+
+    /// The default style for cookies.
+    static let defaultForCookies: Self = .form
+
+    /// Returns the default value of the explode field for the given style
+    /// - Parameter style: The parameter style.
+    static func defaultExplodeFor(forStyle style: ParameterStyle) -> Bool {
+        style == .form
+    }
+}

--- a/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
+++ b/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
@@ -1046,7 +1046,7 @@ extension Converter {
 
     //    | server | get | request query | text | string-convertible | optional | getOptionalQueryItemAsText |
     @available(*, deprecated)
-    func getOptionalQueryItemAsText<T: _StringConvertible>(
+    public func getOptionalQueryItemAsText<T: _StringConvertible>(
         in queryParameters: [URLQueryItem],
         name: String,
         as type: T.Type
@@ -1063,7 +1063,7 @@ extension Converter {
 
     //    | server | get | request query | text | string-convertible | required | getRequiredQueryItemAsText |
     @available(*, deprecated)
-    func getRequiredQueryItemAsText<T: _StringConvertible>(
+    public func getRequiredQueryItemAsText<T: _StringConvertible>(
         in queryParameters: [URLQueryItem],
         name: String,
         as type: T.Type
@@ -1080,7 +1080,7 @@ extension Converter {
 
     //    | server | get | request query | text | array of string-convertibles | optional | getOptionalQueryItemAsText |
     @available(*, deprecated)
-    func getOptionalQueryItemAsText<T: _StringConvertible>(
+    public func getOptionalQueryItemAsText<T: _StringConvertible>(
         in queryParameters: [URLQueryItem],
         name: String,
         as type: [T].Type
@@ -1097,7 +1097,7 @@ extension Converter {
 
     //    | server | get | request query | text | array of string-convertibles | required | getRequiredQueryItemAsText |
     @available(*, deprecated)
-    func getRequiredQueryItemAsText<T: _StringConvertible>(
+    public func getRequiredQueryItemAsText<T: _StringConvertible>(
         in queryParameters: [URLQueryItem],
         name: String,
         as type: [T].Type
@@ -1114,7 +1114,7 @@ extension Converter {
 
     //    | server | get | request query | text | date | optional | getOptionalQueryItemAsText |
     @available(*, deprecated)
-    func getOptionalQueryItemAsText(
+    public func getOptionalQueryItemAsText(
         in queryParameters: [URLQueryItem],
         name: String,
         as type: Date.Type
@@ -1131,7 +1131,7 @@ extension Converter {
 
     //    | server | get | request query | text | date | required | getRequiredQueryItemAsText |
     @available(*, deprecated)
-    func getRequiredQueryItemAsText(
+    public func getRequiredQueryItemAsText(
         in queryParameters: [URLQueryItem],
         name: String,
         as type: Date.Type
@@ -1148,7 +1148,7 @@ extension Converter {
 
     //    | server | get | request query | text | array of dates | optional | getOptionalQueryItemAsText |
     @available(*, deprecated)
-    func getOptionalQueryItemAsText(
+    public func getOptionalQueryItemAsText(
         in queryParameters: [URLQueryItem],
         name: String,
         as type: [Date].Type
@@ -1165,7 +1165,7 @@ extension Converter {
 
     //    | server | get | request query | text | array of dates | required | getRequiredQueryItemAsText |
     @available(*, deprecated)
-    func getRequiredQueryItemAsText(
+    public func getRequiredQueryItemAsText(
         in queryParameters: [URLQueryItem],
         name: String,
         as type: [Date].Type

--- a/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
+++ b/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
@@ -975,4 +975,208 @@ extension Converter {
         let convertibleValue = body.value
         return try convert(convertibleValue)
     }
+
+    //    | client | set | request query | text | string-convertible | both | setQueryItemAsText |
+    @available(*, deprecated)
+    public func setQueryItemAsText<T: _StringConvertible>(
+        in request: inout Request,
+        name: String,
+        value: T?
+    ) throws {
+        try setQueryItem(
+            in: &request,
+            style: nil,
+            explode: nil,
+            name: name,
+            value: value,
+            convert: convertStringConvertibleToText
+        )
+    }
+
+    //    | client | set | request query | text | array of string-convertibles | both | setQueryItemAsText |
+    @available(*, deprecated)
+    public func setQueryItemAsText<T: _StringConvertible>(
+        in request: inout Request,
+        name: String,
+        value: [T]?
+    ) throws {
+        try setQueryItems(
+            in: &request,
+            style: nil,
+            explode: nil,
+            name: name,
+            values: value,
+            convert: convertStringConvertibleToText
+        )
+    }
+
+    //    | client | set | request query | text | date | both | setQueryItemAsText |
+    @available(*, deprecated)
+    public func setQueryItemAsText(
+        in request: inout Request,
+        name: String,
+        value: Date?
+    ) throws {
+        try setQueryItem(
+            in: &request,
+            style: nil,
+            explode: nil,
+            name: name,
+            value: value,
+            convert: convertDateToText
+        )
+    }
+
+    //    | client | set | request query | text | array of dates | both | setQueryItemAsText |
+    @available(*, deprecated)
+    public func setQueryItemAsText(
+        in request: inout Request,
+        name: String,
+        value: [Date]?
+    ) throws {
+        try setQueryItems(
+            in: &request,
+            style: nil,
+            explode: nil,
+            name: name,
+            values: value,
+            convert: convertDateToText
+        )
+    }
+
+    //    | server | get | request query | text | string-convertible | optional | getOptionalQueryItemAsText |
+    @available(*, deprecated)
+    func getOptionalQueryItemAsText<T: _StringConvertible>(
+        in queryParameters: [URLQueryItem],
+        name: String,
+        as type: T.Type
+    ) throws -> T? {
+        try getOptionalQueryItem(
+            in: queryParameters,
+            style: nil,
+            explode: nil,
+            name: name,
+            as: type,
+            convert: convertTextToStringConvertible
+        )
+    }
+
+    //    | server | get | request query | text | string-convertible | required | getRequiredQueryItemAsText |
+    @available(*, deprecated)
+    func getRequiredQueryItemAsText<T: _StringConvertible>(
+        in queryParameters: [URLQueryItem],
+        name: String,
+        as type: T.Type
+    ) throws -> T {
+        try getRequiredQueryItem(
+            in: queryParameters,
+            style: nil,
+            explode: nil,
+            name: name,
+            as: type,
+            convert: convertTextToStringConvertible
+        )
+    }
+
+    //    | server | get | request query | text | array of string-convertibles | optional | getOptionalQueryItemAsText |
+    @available(*, deprecated)
+    func getOptionalQueryItemAsText<T: _StringConvertible>(
+        in queryParameters: [URLQueryItem],
+        name: String,
+        as type: [T].Type
+    ) throws -> [T]? {
+        try getOptionalQueryItems(
+            in: queryParameters,
+            style: nil,
+            explode: nil,
+            name: name,
+            as: type,
+            convert: convertTextToStringConvertible
+        )
+    }
+
+    //    | server | get | request query | text | array of string-convertibles | required | getRequiredQueryItemAsText |
+    @available(*, deprecated)
+    func getRequiredQueryItemAsText<T: _StringConvertible>(
+        in queryParameters: [URLQueryItem],
+        name: String,
+        as type: [T].Type
+    ) throws -> [T] {
+        try getRequiredQueryItems(
+            in: queryParameters,
+            style: nil,
+            explode: nil,
+            name: name,
+            as: type,
+            convert: convertTextToStringConvertible
+        )
+    }
+
+    //    | server | get | request query | text | date | optional | getOptionalQueryItemAsText |
+    @available(*, deprecated)
+    func getOptionalQueryItemAsText(
+        in queryParameters: [URLQueryItem],
+        name: String,
+        as type: Date.Type
+    ) throws -> Date? {
+        try getOptionalQueryItem(
+            in: queryParameters,
+            style: nil,
+            explode: nil,
+            name: name,
+            as: type,
+            convert: convertTextToDate
+        )
+    }
+
+    //    | server | get | request query | text | date | required | getRequiredQueryItemAsText |
+    @available(*, deprecated)
+    func getRequiredQueryItemAsText(
+        in queryParameters: [URLQueryItem],
+        name: String,
+        as type: Date.Type
+    ) throws -> Date {
+        try getRequiredQueryItem(
+            in: queryParameters,
+            style: nil,
+            explode: nil,
+            name: name,
+            as: type,
+            convert: convertTextToDate
+        )
+    }
+
+    //    | server | get | request query | text | array of dates | optional | getOptionalQueryItemAsText |
+    @available(*, deprecated)
+    func getOptionalQueryItemAsText(
+        in queryParameters: [URLQueryItem],
+        name: String,
+        as type: [Date].Type
+    ) throws -> [Date]? {
+        try getOptionalQueryItems(
+            in: queryParameters,
+            style: nil,
+            explode: nil,
+            name: name,
+            as: type,
+            convert: convertTextToDate
+        )
+    }
+
+    //    | server | get | request query | text | array of dates | required | getRequiredQueryItemAsText |
+    @available(*, deprecated)
+    func getRequiredQueryItemAsText(
+        in queryParameters: [URLQueryItem],
+        name: String,
+        as type: [Date].Type
+    ) throws -> [Date] {
+        try getRequiredQueryItems(
+            in: queryParameters,
+            style: nil,
+            explode: nil,
+            name: name,
+            as: type,
+            convert: convertTextToDate
+        )
+    }
 }

--- a/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
+++ b/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
@@ -24,6 +24,15 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
     // Data conversion
     case failedToDecodeStringConvertibleValue(type: String)
 
+    enum ParameterLocation: String, CustomStringConvertible {
+        case query
+
+        var description: String {
+            rawValue
+        }
+    }
+    case unsupportedParameterStyle(name: String, location: ParameterLocation, style: ParameterStyle, explode: Bool)
+
     // Headers
     case missingRequiredHeaderField(String)
     case unexpectedContentTypeHeader(String)
@@ -56,6 +65,9 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
             return "Invalid expected content type: '\(string)'"
         case .failedToDecodeStringConvertibleValue(let string):
             return "Failed to decode a value of type '\(string)'."
+        case .unsupportedParameterStyle(name: let name, location: let location, style: let style, explode: let explode):
+            return
+                "Unsupported parameter style, parameter name: '\(name)', kind: \(location), style: \(style), explode: \(explode)"
         case .missingRequiredHeaderField(let name):
             return "The required header field named '\(name)' is missing."
         case .unexpectedContentTypeHeader(let contentType):

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Client.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Client.swift
@@ -35,6 +35,8 @@ final class Test_ClientConverterExtensions: Test_Runtime {
         var request = testRequest
         try converter.setQueryItemAsText(
             in: &request,
+            style: nil,
+            explode: nil,
             name: "search",
             value: "foo"
         )
@@ -45,6 +47,8 @@ final class Test_ClientConverterExtensions: Test_Runtime {
         var request = testRequest
         try converter.setQueryItemAsText(
             in: &request,
+            style: nil,
+            explode: nil,
             name: "search",
             value: "h%llo"
         )
@@ -56,6 +60,8 @@ final class Test_ClientConverterExtensions: Test_Runtime {
         var request = testRequest
         try converter.setQueryItemAsText(
             in: &request,
+            style: nil,
+            explode: nil,
             name: "search",
             value: ["foo", "bar"]
         )
@@ -67,6 +73,7 @@ final class Test_ClientConverterExtensions: Test_Runtime {
         var request = testRequest
         try converter.setQueryItemAsText(
             in: &request,
+            style: nil,
             explode: false,
             name: "search",
             value: ["foo", "bar"]
@@ -79,6 +86,8 @@ final class Test_ClientConverterExtensions: Test_Runtime {
         var request = testRequest
         try converter.setQueryItemAsText(
             in: &request,
+            style: nil,
+            explode: nil,
             name: "search",
             value: testDate
         )
@@ -90,6 +99,8 @@ final class Test_ClientConverterExtensions: Test_Runtime {
         var request = testRequest
         try converter.setQueryItemAsText(
             in: &request,
+            style: nil,
+            explode: nil,
             name: "search",
             value: [testDate, testDate]
         )

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Client.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Client.swift
@@ -62,6 +62,18 @@ final class Test_ClientConverterExtensions: Test_Runtime {
         XCTAssertEqual(request.query, "search=foo&search=bar")
     }
 
+    //    | client | set | request query | text | array of string-convertibles | both | setQueryItemAsText |
+    func test_setQueryItemAsText_arrayOfStringConvertibles_unexploded() throws {
+        var request = testRequest
+        try converter.setQueryItemAsText(
+            in: &request,
+            explode: false,
+            name: "search",
+            value: ["foo", "bar"]
+        )
+        XCTAssertEqual(request.query, "search=foo,bar")
+    }
+
     //    | client | set | request query | text | date | both | setQueryItemAsText |
     func test_setQueryItemAsText_date() throws {
         var request = testRequest

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
@@ -123,6 +123,8 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         ]
         let value: String? = try converter.getOptionalQueryItemAsText(
             in: query,
+            style: nil,
+            explode: nil,
             name: "search",
             as: String.self
         )
@@ -136,6 +138,8 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         ]
         let value: String = try converter.getRequiredQueryItemAsText(
             in: query,
+            style: nil,
+            explode: nil,
             name: "search",
             as: String.self
         )
@@ -150,6 +154,8 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         ]
         let value: [String]? = try converter.getOptionalQueryItemAsText(
             in: query,
+            style: nil,
+            explode: nil,
             name: "search",
             as: [String].self
         )
@@ -164,6 +170,8 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         ]
         let value: [String] = try converter.getRequiredQueryItemAsText(
             in: query,
+            style: nil,
+            explode: nil,
             name: "search",
             as: [String].self
         )
@@ -177,6 +185,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         ]
         let value: [String] = try converter.getRequiredQueryItemAsText(
             in: query,
+            style: nil,
             explode: false,
             name: "search",
             as: [String].self
@@ -191,6 +200,8 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         ]
         let value: Date? = try converter.getOptionalQueryItemAsText(
             in: query,
+            style: nil,
+            explode: nil,
             name: "search",
             as: Date.self
         )
@@ -204,6 +215,8 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         ]
         let value: Date = try converter.getRequiredQueryItemAsText(
             in: query,
+            style: nil,
+            explode: nil,
             name: "search",
             as: Date.self
         )
@@ -218,6 +231,8 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         ]
         let value: [Date]? = try converter.getOptionalQueryItemAsText(
             in: query,
+            style: nil,
+            explode: nil,
             name: "search",
             as: [Date].self
         )
@@ -232,6 +247,8 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         ]
         let value: [Date] = try converter.getRequiredQueryItemAsText(
             in: query,
+            style: nil,
+            explode: nil,
             name: "search",
             as: [Date].self
         )

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
@@ -170,6 +170,20 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         XCTAssertEqual(value, ["foo", "bar"])
     }
 
+    //    | server | get | request query | text | array of string-convertibles | required | getRequiredQueryItemAsText |
+    func test_getRequiredQueryItemAsText_arrayOfStringConvertibles_unexploded() throws {
+        let query: [URLQueryItem] = [
+            .init(name: "search", value: "foo,bar")
+        ]
+        let value: [String] = try converter.getRequiredQueryItemAsText(
+            in: query,
+            explode: false,
+            name: "search",
+            as: [String].self
+        )
+        XCTAssertEqual(value, ["foo", "bar"])
+    }
+
     //    | server | get | request query | text | date | optional | getOptionalQueryItemAsText |
     func test_getOptionalQueryItemAsText_date() throws {
         let query: [URLQueryItem] = [

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_FoundationExtensions.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_FoundationExtensions.swift
@@ -18,7 +18,23 @@ final class Test_FoundationExtensions: Test_Runtime {
 
     func testURLComponents_addStringQueryItem() throws {
         var components = testComponents
-        components.addStringQueryItem(name: "key", value: "value")
+        components.addStringQueryItem(name: "key", value: "value", explode: true)
         XCTAssertEqualURLString(components.url, "/api?key=value")
+    }
+
+    func testURLComponents_addStringQueryItems() throws {
+        var components = testComponents
+        components.addStringQueryItem(name: "key2", value: "value3", explode: true)
+        components.addStringQueryItem(name: "key", value: "value1", explode: true)
+        components.addStringQueryItem(name: "key", value: "value2", explode: true)
+        XCTAssertEqualURLString(components.url, "/api?key2=value3&key=value1&key=value2")
+    }
+
+    func testURLComponents_addStringQueryItems_unexploded() throws {
+        var components = testComponents
+        components.addStringQueryItem(name: "key2", value: "value3", explode: false)
+        components.addStringQueryItem(name: "key", value: "value1", explode: false)
+        components.addStringQueryItem(name: "key", value: "value2", explode: false)
+        XCTAssertEqualURLString(components.url, "/api?key2=value3&key=value1,value2")
     }
 }


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apple/swift-openapi-generator/issues/52.

By default, query items are encoded as exploded (`key=value1&key=value2`), but OpenAPI allows explicitly requesting them unexploded (`key=value1,value2`). This feature missing has shown up in a few OpenAPI documents recently.

### Modifications

Add support for unexploded query items by expanding the helper functions and allow passing in `style` and `explode` parameters. The `style` is in preparation of also supporting alternative styles, but for now we just validate that only the supported style is provided.

### Result

Generated code can use these improved helper functions to encode/decode unexploded query items.

### Test Plan

Updated/added unit tests for unexploded query items.
