### PR TITLE
Use Swift tools 5.7

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.7
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project


### PR DESCRIPTION
### Motivation

I am on macOS Monterey using Xcode 14.7 (which ships with Swift 5.7.1) which is the last supported version of Xcode on this release of macOS, and I want to use this package, but it is using `swift-tools-version:5.8`

### Modifications

I changed the `swift-tools-version` to `5.7`

### Result

Everything seems to build as expected! Next, I will attempt to open a similar PR on the swift-openapi-generator repo. (And I would greatly appreciate some guidance on when and how to do that; I assume that if I just change the tools version there, it will break, because it won't be using the updated version of this package)

There is one warning generated in a test target, but since I can't build it on my machine, I don't know if the warning was always there or not. Here it is:

```swift
let nestedDict = try XCTUnwrap(decoded.dict.value["nestedDict"] as? [String: Any?])
```
```
Cast from '(any Sendable)??' to unrelated type '[String : Any?]' always fails
```
