### PR TITLE
add converter methods for url forms

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/Converter+Client.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Client.swift
@@ -167,6 +167,32 @@ extension Converter {
             convert: convertDataToBinary
         )
     }
+    
+    //    | client | set | request body | urlEncodedForm | codable | optional | setOptionalRequestBodyAsURLEncodedForm |
+    public func setOptionalRequestBodyAsURLEncodedForm<T: Encodable>(
+        _ value: T,
+        headerFields: inout [HeaderField],
+        contentType: String
+    ) throws -> Data? {
+        try setOptionalRequestBody(value,
+                                   headerFields: &headerFields,
+                                   contentType: contentType,
+                                   convert: convertBodyCodableToURLFormData
+        )
+    }
+    
+    //    | client | set | request body | urlEncodedForm | codable | required | setRequiredRequestBodyAsURLEncodedForm |
+    public func setRequiredRequestBodyAsURLEncodedForm<T: Encodable>(
+        _ value: T,
+        headerFields: inout [HeaderField],
+        contentType: String
+    ) throws -> Data {
+        try setRequiredRequestBody(value,
+                                   headerFields: &headerFields,
+                                   contentType: contentType,
+                                   convert: convertBodyCodableToURLFormData
+        )
+    }
 
     //    | client | get | response body | string | required | getResponseBodyAsString |
     public func getResponseBodyAsString<T: Decodable, C>(

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
@@ -272,6 +272,35 @@ extension Converter {
             convert: convertBinaryToData
         )
     }
+    
+    //    | server | get | request body | URLEncodedForm | codable | optional | getOptionalRequestBodyAsURLEncodedForm |
+    func getOptionalRequestBodyAsURLEncodedForm<T: Decodable, C>(
+        _ type: T.Type,
+        from data: Data?,
+        transforming transform: (T) -> C
+    ) throws -> C? {
+        try getOptionalRequestBody(
+            type,
+            from: data,
+            transforming: transform,
+            convert: convertURLEncodedFormToCodable
+        )
+    }
+
+    //    | server | get | request body | URLEncodedForm | codable | required | getRequiredRequestBodyAsURLEncodedForm |
+    func getRequiredRequestBodyAsURLEncodedForm<T: Decodable, C>(
+        _ type: T.Type,
+        from data: Data?,
+        transforming transform: (T) -> C
+    ) throws -> C {
+        try getRequiredRequestBody(
+            type,
+            from: data,
+            transforming: transform,
+            convert: convertURLEncodedFormToCodable
+        )
+    }
+    
 
     //    | server | set | response body | string | required | setResponseBodyAsString |
     public func setResponseBodyAsString<T: Encodable>(

--- a/Sources/OpenAPIRuntime/Conversion/CurrencyExtensions.swift
+++ b/Sources/OpenAPIRuntime/Conversion/CurrencyExtensions.swift
@@ -176,11 +176,41 @@ extension Converter {
     ) throws -> T {
         try decoder.decode(T.self, from: data)
     }
+    
+    func convertURLEncodedFormToCodable<T:Decodable>(
+        _ data: Data
+    ) throws -> T {
+        
+        let decoder = URIDecoder(configuration: .init(style: .form,
+                                                      explode: true,
+                                                      spaceEscapingCharacter: .percentEncoded,
+                                                      dateTranscoder: configuration.dateTranscoder))
+        guard let uriString = String(data: data, encoding: .utf8) else {
+            throw RuntimeError.failedToSerializeCodableData
+        }
+        
+        return try decoder.decode(T.self, from: uriString)
+    }
 
     func convertBodyCodableToJSON<T: Encodable>(
         _ value: T
     ) throws -> Data {
         try encoder.encode(value)
+    }
+    
+    func convertBodyCodableToURLFormData<T: Encodable>(
+        _ value: T
+    ) throws -> Data {
+        
+        let encoder = URIEncoder(configuration: .init(style: .form,
+                                                      explode: true,
+                                                      spaceEscapingCharacter: .percentEncoded,
+                                                      dateTranscoder: configuration.dateTranscoder))
+        guard let data = try encoder.encode(value, forKey: "").data(using: .utf8) else {
+            throw RuntimeError.failedToDecodeStringConvertibleValue(type: String(describing: T.self))
+        }
+        
+        return data
     }
 
     func convertHeaderFieldCodableToJSON<T: Encodable>(

--- a/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
+++ b/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
@@ -23,6 +23,7 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
 
     // Data conversion
     case failedToDecodeStringConvertibleValue(type: String)
+    case failedToSerializeCodableData
 
     enum ParameterLocation: String, CustomStringConvertible {
         case query
@@ -66,6 +67,8 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
             return "Invalid expected content type: '\(string)'"
         case .failedToDecodeStringConvertibleValue(let string):
             return "Failed to decode a value of type '\(string)'."
+        case .failedToSerializeCodableData:
+            return "Failed to serialize codable data."
         case .unsupportedParameterStyle(name: let name, location: let location, style: let style, explode: let explode):
             return
                 "Unsupported parameter style, parameter name: '\(name)', kind: \(location), style: \(style), explode: \(explode)"

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Client.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Client.swift
@@ -233,6 +233,59 @@ final class Test_ClientConverterExtensions: Test_Runtime {
             ]
         )
     }
+    
+    //    | client | set | request body | urlEncodedForm | codable | optional | setRequiredRequestBodyAsURLEncodedForm |
+    func test_setOptionalRequestBodyAsURLEncodedForm_codable() throws {
+        var headerFields: [HeaderField] = []
+        let body = try converter.setOptionalRequestBodyAsURLEncodedForm(
+            testStructDetailed,
+            headerFields: &headerFields,
+            contentType: "application/x-www-form-urlencoded"
+        )
+
+        XCTAssertEqual(body, testStructURLFormData)
+        XCTAssertEqual(
+            headerFields,
+            [
+                .init(name: "content-type", value: "application/x-www-form-urlencoded")
+            ]
+        )
+    }
+    
+    //    | client | set | request body | urlEncodedForm | codable | required | setRequiredRequestBodyAsURLEncodedForm |
+    func test_setRequiredRequestBodyAsURLEncodedForm_codable_string() throws {
+        var headerFields: [HeaderField] = []
+        let body = try converter.setRequiredRequestBodyAsURLEncodedForm(
+            testStructDetailed,
+            headerFields: &headerFields,
+            contentType: "application/x-www-form-urlencoded"
+        )
+
+        XCTAssertEqual(String(data: body, encoding: .utf8), testStructURLFormString)
+        XCTAssertEqual(
+            headerFields,
+            [
+                .init(name: "content-type", value: "application/x-www-form-urlencoded")
+            ]
+        )
+    }
+    
+    func test_setRequiredRequestBodyAsURLEncodedForm_codable() throws {
+        var headerFields: [HeaderField] = []
+        let body = try converter.setRequiredRequestBodyAsURLEncodedForm(
+            testStructDetailed,
+            headerFields: &headerFields,
+            contentType: "application/x-www-form-urlencoded"
+        )
+
+        XCTAssertEqual(body, testStructURLFormData)
+        XCTAssertEqual(
+            headerFields,
+            [
+                .init(name: "content-type", value: "application/x-www-form-urlencoded")
+            ]
+        )
+    }
 
     //    | client | set | request body | binary | optional | setOptionalRequestBodyAsBinary |
     func test_setOptionalRequestBodyAsBinary_data() throws {

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
@@ -338,6 +338,26 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         )
         XCTAssertEqual(body, testStruct)
     }
+    
+    //    | server | get | request body | URLEncodedForm | optional | getOptionalRequestBodyAsJSON |
+    func test_getOptionalRequestBodyAsURLEncodedForm_codable() throws {
+        let body: TestPetDetailed? = try converter.getOptionalRequestBodyAsURLEncodedForm(
+            TestPetDetailed.self,
+            from: testStructURLFormData,
+            transforming: { $0 }
+        )
+        XCTAssertEqual(body, testStructDetailed)
+    }
+
+    //    | server | get | request body | URLEncodedForm | required | getRequiredRequestBodyAsJSON |
+    func test_getRequiredRequestBodyAsURLEncodedForm_codable() throws {
+        let body: TestPetDetailed = try converter.getRequiredRequestBodyAsURLEncodedForm(
+            TestPetDetailed.self,
+            from: testStructURLFormData,
+            transforming: { $0 }
+        )
+        XCTAssertEqual(body, testStructDetailed)
+    }
 
     //    | server | get | request body | binary | optional | getOptionalRequestBodyAsBinary |
     func test_getOptionalRequestBodyAsBinary_data() throws {

--- a/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
+++ b/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
@@ -85,6 +85,10 @@ class Test_Runtime: XCTestCase {
     var testStruct: TestPet {
         .init(name: "Fluffz")
     }
+    
+    var testStructDetailed: TestPetDetailed {
+        .init(name: "Fluffz", type: "Dog", age: "3")
+    }
 
     var testStructString: String {
         #"{"name":"Fluffz"}"#
@@ -96,6 +100,10 @@ class Test_Runtime: XCTestCase {
           "name" : "Fluffz"
         }
         """#
+    }
+    
+    var testStructURLFormString: String {
+        "age=3&name=Fluffz&type=Dog"
     }
 
     var testEnum: TestHabitat {
@@ -112,6 +120,10 @@ class Test_Runtime: XCTestCase {
 
     var testStructPrettyData: Data {
         Data(testStructPrettyString.utf8)
+    }
+    
+    var testStructURLFormData: Data {
+        Data(testStructURLFormString.utf8)
     }
 
     func _testPrettyEncoded<Value: Encodable>(_ value: Value, expectedJSON: String) throws {
@@ -138,6 +150,12 @@ public func XCTAssertEqualURLString(_ lhs: URL?, _ rhs: String, file: StaticStri
 
 struct TestPet: Codable, Equatable {
     var name: String
+}
+
+struct TestPetDetailed: Codable, Equatable {
+    var name: String
+    var type: String
+    var age: String
 }
 
 enum TestHabitat: String, Codable, Equatable {


### PR DESCRIPTION
### Motivation

[Linked generator PR](https://github.com/apple/swift-openapi-generator/pull/195)

This is a draft PR to receive feedback on [issue 182](https://github.com/apple/swift-openapi-generator/issues/182). However the latest discussion there recommends that we work towards a custom URLFormEncoder/Decoder that should replace the majority of the logic in these methods. Ideally, they would look identical to their JSON method counterparts: `encoder.encode(value)`, rather that implementing the steps here.

### Modifications

Add converter methods for a new url form method. For this implementation, we're leaning on the JSONEncoder, which definitely has its drawbacks. As the discussion on the issue evolves, it's clear that a more custom approach would be better.

### Result

The matching [generator PR](https://github.com/apple/swift-openapi-generator/pull/195) changes the implementation of url encoded forms, but the runtime changes here are additional methods, so nothing will change with existing implementations

### Test Plan

No tests added as of yet.
