### PR TITLE
[Runtime] Stop generating an undocumented case for enums/oneOfs

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/ErrorExtensions.swift
+++ b/Sources/OpenAPIRuntime/Conversion/ErrorExtensions.swift
@@ -35,6 +35,27 @@ extension DecodingError {
             )
         )
     }
+
+    /// Returns a decoding error used by the oneOf decoder when not a single
+    /// child schema decodes the received payload.
+    /// - Parameters:
+    ///   - type: The type representing the oneOf schema in which the decoding
+    ///   occurred.
+    ///   - codingPath: The coding path to the decoder that attempted to decode
+    ///   the type.
+    /// - Returns: A decoding error.
+    static func failedToDecodeOneOfSchema(
+        type: Any.Type,
+        codingPath: [any CodingKey]
+    ) -> Self {
+        DecodingError.valueNotFound(
+            type,
+            DecodingError.Context.init(
+                codingPath: codingPath,
+                debugDescription: "The oneOf structure did not decode into any child schema."
+            )
+        )
+    }
 }
 
 @_spi(Generated)

--- a/Sources/OpenAPIRuntime/Conversion/ErrorExtensions.swift
+++ b/Sources/OpenAPIRuntime/Conversion/ErrorExtensions.swift
@@ -44,7 +44,8 @@ extension DecodingError {
     ///   - codingPath: The coding path to the decoder that attempted to decode
     ///   the type.
     /// - Returns: A decoding error.
-    static func failedToDecodeOneOfSchema(
+    @_spi(Generated)
+    public static func failedToDecodeOneOfSchema(
         type: Any.Type,
         codingPath: [any CodingKey]
     ) -> Self {


### PR DESCRIPTION
### Motivation

Runtime side of https://github.com/apple/swift-openapi-generator/pull/205

### Modifications

Added a helper function that produces the right error.

### Result

Generated code can use this error to throw when an unknown case is encountered.

### Test Plan

Tested together with the generator.
