### PR TITLE
Remove redundant explicit Equatable conformances

### DIFF
--- a/Sources/OpenAPIRuntime/Base/CommonOutputPayloads.swift
+++ b/Sources/OpenAPIRuntime/Base/CommonOutputPayloads.swift
@@ -19,7 +19,7 @@
 /// not all are defined by the user in the OpenAPI document, an extra
 /// `undocumented` enum case is used when such a status code is
 /// detected.
-public struct UndocumentedPayload: Sendable, Equatable, Hashable {
+public struct UndocumentedPayload: Sendable, Hashable {
     /// Creates a new payload.
     public init() {}
 }

--- a/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
+++ b/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
@@ -33,7 +33,7 @@
 ///
 /// - Important: This type is expensive at runtime; try to avoid it.
 /// Define the structure of your types in the OpenAPI document instead.
-public struct OpenAPIValueContainer: Codable, Equatable, Hashable, Sendable {
+public struct OpenAPIValueContainer: Codable, Hashable, Sendable {
 
     /// The underlying dynamic value.
     public var value: (any Sendable)?
@@ -278,7 +278,7 @@ extension OpenAPIValueContainer: ExpressibleByFloatLiteral {
 ///
 /// - Important: This type is expensive at runtime; try to avoid it.
 /// Define the structure of your types in the OpenAPI document instead.
-public struct OpenAPIObjectContainer: Codable, Equatable, Hashable, Sendable {
+public struct OpenAPIObjectContainer: Codable, Hashable, Sendable {
 
     /// The underlying dynamic dictionary value.
     public var value: [String: (any Sendable)?]
@@ -382,7 +382,7 @@ public struct OpenAPIObjectContainer: Codable, Equatable, Hashable, Sendable {
 ///
 /// - Important: This type is expensive at runtime; try to avoid it.
 /// Define the structure of your types in the OpenAPI document instead.
-public struct OpenAPIArrayContainer: Codable, Equatable, Hashable, Sendable {
+public struct OpenAPIArrayContainer: Codable, Hashable, Sendable {
 
     /// The underlying dynamic array value.
     public var value: [(any Sendable)?]

--- a/Sources/OpenAPIRuntime/Conversion/CodableExtensions.swift
+++ b/Sources/OpenAPIRuntime/Conversion/CodableExtensions.swift
@@ -149,7 +149,7 @@ extension Encoder {
 }
 
 /// A freeform String coding key for decoding undocumented values.
-private struct StringKey: CodingKey, Equatable, Hashable, Comparable {
+private struct StringKey: CodingKey, Hashable, Comparable {
 
     var stringValue: String
     var intValue: Int? {

--- a/Sources/OpenAPIRuntime/Interface/CurrencyTypes.swift
+++ b/Sources/OpenAPIRuntime/Interface/CurrencyTypes.swift
@@ -19,7 +19,7 @@ import Foundation
 #endif
 
 /// A header field used in an HTTP request or response.
-public struct HeaderField: Equatable, Hashable, Sendable {
+public struct HeaderField: Hashable, Sendable {
 
     /// The name of the HTTP header field.
     public var name: String
@@ -40,10 +40,10 @@ public struct HeaderField: Equatable, Hashable, Sendable {
 /// Describes the HTTP method used in an OpenAPI operation.
 ///
 /// https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#fixed-fields-7
-public struct HTTPMethod: RawRepresentable, Equatable, Hashable, Sendable {
+public struct HTTPMethod: RawRepresentable, Hashable, Sendable {
 
     /// Describes an HTTP method explicitly supported by OpenAPI.
-    private enum OpenAPIHTTPMethod: String, Equatable, Hashable, Sendable {
+    private enum OpenAPIHTTPMethod: String, Hashable, Sendable {
         case GET
         case PUT
         case POST
@@ -120,7 +120,7 @@ public struct HTTPMethod: RawRepresentable, Equatable, Hashable, Sendable {
 }
 
 /// An HTTP request, sent by the client to the server.
-public struct Request: Equatable, Hashable, Sendable {
+public struct Request: Hashable, Sendable {
 
     /// The path of the URL for the HTTP request.
     public var path: String
@@ -199,7 +199,7 @@ public struct Request: Equatable, Hashable, Sendable {
 }
 
 /// An HTTP response, returned by the server to the client.
-public struct Response: Equatable, Hashable, Sendable {
+public struct Response: Hashable, Sendable {
 
     /// The status code of the HTTP response, for example `200`.
     public var statusCode: Int
@@ -228,7 +228,7 @@ public struct Response: Equatable, Hashable, Sendable {
 
 /// A container for request metadata already parsed and validated
 /// by the server transport.
-public struct ServerRequestMetadata: Equatable, Hashable, Sendable {
+public struct ServerRequestMetadata: Hashable, Sendable {
 
     /// The path parameters parsed from the URL of the HTTP request.
     public var pathParameters: [String: String]
@@ -252,7 +252,7 @@ public struct ServerRequestMetadata: Equatable, Hashable, Sendable {
 }
 
 /// Describes the kind and associated data of a URL path component.
-public enum RouterPathComponent: Equatable, Hashable, Sendable {
+public enum RouterPathComponent: Hashable, Sendable {
 
     /// A constant string component.
     ///


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apple/swift-openapi-generator/issues/210.

### Modifications

Types conforming to `Hashable` do not need to explicity declare that they conform to `Equatable`. 

With this pull request, we are removing the explicit `Equatable` conformance of types already conforming to `Hashable` in the code base.

### Result

Types conforming to `Hashable` do explicitly declare a redundant conformance to `Equatable`.

### Test Plan

N/A
