### PR TITLE
Add an escaped path component test case

### DIFF
--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
@@ -125,7 +125,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
             "foo": "bar",
             "number": "1",
             "habitats": "land,air",
-            "withEscaping": "Hello%20world%21"
+            "withEscaping": "Hello%20world%21",
         ]
         do {
             let value = try converter.getPathParameterAsURI(

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
@@ -125,6 +125,7 @@ final class Test_ServerConverterExtensions: Test_Runtime {
             "foo": "bar",
             "number": "1",
             "habitats": "land,air",
+            "withEscaping": "Hello%20world%21"
         ]
         do {
             let value = try converter.getPathParameterAsURI(
@@ -149,6 +150,14 @@ final class Test_ServerConverterExtensions: Test_Runtime {
                 as: [TestHabitat].self
             )
             XCTAssertEqual(value, [.land, .air])
+        }
+        do {
+            let value = try converter.getPathParameterAsURI(
+                in: path,
+                name: "withEscaping",
+                as: String.self
+            )
+            XCTAssertEqual(value, "Hello world!")
         }
     }
 


### PR DESCRIPTION
### Motivation

While investigating https://github.com/apple/swift-openapi-generator/issues/251 I noticed we don't have a test case for an escaped path component.

### Modifications

Added an extra test case.

### Result

Unescaping path params has better test coverage.

### Test Plan

This whole PR is about improving the tests.
