### PR TITLE
[Runtime] Fix nested coding

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/CodableExtensions.swift
+++ b/Sources/OpenAPIRuntime/Conversion/CodableExtensions.swift
@@ -90,6 +90,16 @@ extension Decoder {
         return .init(uniqueKeysWithValues: keyValuePairs)
     }
 
+    /// Returns the decoded value by using a single value container.
+    /// - Parameter type: The type to decode.
+    /// - Returns: The decoded value.
+    public func decodeFromSingleValueContainer<T: Decodable>(
+        _ type: T.Type = T.self
+    ) throws -> T {
+        let container = try singleValueContainer()
+        return try container.decode(T.self)
+    }
+
     // MARK: - Private
 
     /// Returns the keys in the given decoder that are not present
@@ -144,6 +154,29 @@ extension Encoder {
         var container = container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {
             try container.encode(value, forKey: .init(key))
+        }
+    }
+
+    /// Encodes the value into the encoder using a single value container.
+    /// - Parameter value: The value to encode.
+    public func encodeToSingleValueContainer<T: Encodable>(
+        _ value: T
+    ) throws {
+        var container = singleValueContainer()
+        try container.encode(value)
+    }
+
+    /// Encodes the first non-nil value from the provided array into
+    /// the encoder using a single value container.
+    /// - Parameter values: An array of optional values.
+    public func encodeFirstNonNilValueToSingleValueContainer(
+        _ values: [(any Encodable)?]
+    ) throws {
+        for value in values {
+            if let value {
+                try encodeToSingleValueContainer(value)
+                return
+            }
         }
     }
 }

--- a/Sources/OpenAPIRuntime/URICoder/Decoding/URIValueFromNodeDecoder.swift
+++ b/Sources/OpenAPIRuntime/URICoder/Decoding/URIValueFromNodeDecoder.swift
@@ -98,9 +98,6 @@ extension URIValueFromNodeDecoder {
     /// A decoder error.
     enum GeneralError: Swift.Error {
 
-        /// The decoder does not support the provided type.
-        case unsupportedType(Any.Type)
-
         /// The decoder was asked to create a nested container.
         case nestedContainersNotSupported
 
@@ -274,7 +271,7 @@ extension URIValueFromNodeDecoder {
     /// Extracts the node at the top of the coding stack and tries to treat it
     /// as a primitive value.
     /// - Returns: The value if it can be treated as a primitive value.
-    private func currentElementAsSingleValue() throws -> URIParsedValue {
+    func currentElementAsSingleValue() throws -> URIParsedValue {
         try nodeAsSingleValue(currentElement)
     }
 
@@ -368,11 +365,6 @@ extension URIValueFromNodeDecoder: Decoder {
     }
 
     func singleValueContainer() throws -> any SingleValueDecodingContainer {
-        let value = try currentElementAsSingleValue()
-        return URISingleValueDecodingContainer(
-            dateTranscoder: dateTranscoder,
-            codingPath: codingPath,
-            value: value
-        )
+        return URISingleValueDecodingContainer(decoder: self)
     }
 }

--- a/Sources/OpenAPIRuntime/URICoder/Encoding/URIValueToNodeEncoder+Single.swift
+++ b/Sources/OpenAPIRuntime/URICoder/Encoding/URIValueToNodeEncoder+Single.swift
@@ -144,7 +144,7 @@ extension URISingleValueEncodingContainer: SingleValueEncodingContainer {
         case let value as Date:
             try _setValue(.date(value))
         default:
-            throw URIValueToNodeEncoder.GeneralError.nestedValueInSingleValueContainer
+            try value.encode(to: encoder)
         }
     }
 }

--- a/Sources/OpenAPIRuntime/URICoder/Encoding/URIValueToNodeEncoder.swift
+++ b/Sources/OpenAPIRuntime/URICoder/Encoding/URIValueToNodeEncoder.swift
@@ -40,9 +40,6 @@ final class URIValueToNodeEncoder {
 
         /// The encoder set a value for an index out of range of the container.
         case integerOutOfRange
-
-        /// The encoder tried to treat
-        case nestedValueInSingleValueContainer
     }
 
     /// The stack of nested values within the root node.

--- a/Tests/OpenAPIRuntimeTests/URICoder/Test_URICodingRoundtrip.swift
+++ b/Tests/OpenAPIRuntimeTests/URICoder/Test_URICodingRoundtrip.swift
@@ -13,6 +13,9 @@
 //===----------------------------------------------------------------------===//
 import XCTest
 @_spi(Generated)@testable import OpenAPIRuntime
+#if os(Linux)
+@preconcurrency import Foundation
+#endif
 
 final class Test_URICodingRoundtrip: Test_Runtime {
 


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apple/swift-openapi-generator/issues/263.

### Modifications

Makes URIEncoder/URIDecoder able to handle custom Codable types in a single value container.

For more details check out the associated generator [PR](https://github.com/apple/swift-openapi-generator/pull/271).

### Result

More Codable types can be handled.

### Test Plan

Updated unit tests.
