### PR TITLE
[Bug] Make a missing converter helper public

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
@@ -274,7 +274,7 @@ extension Converter {
     }
 
     //    | server | get | request body | URLEncodedForm | codable | optional | getOptionalRequestBodyAsURLEncodedForm |
-    func getOptionalRequestBodyAsURLEncodedForm<T: Decodable, C>(
+    public func getOptionalRequestBodyAsURLEncodedForm<T: Decodable, C>(
         _ type: T.Type,
         from data: Data?,
         transforming transform: (T) -> C

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Client.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Client.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-@_spi(Generated)@testable import OpenAPIRuntime
+@_spi(Generated) import OpenAPIRuntime
 
 final class Test_ClientConverterExtensions: Test_Runtime {
 

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-@_spi(Generated)@testable import OpenAPIRuntime
+@_spi(Generated) import OpenAPIRuntime
 
 final class Test_CommonConverterExtensions: Test_Runtime {
 

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-@_spi(Generated)@testable import OpenAPIRuntime
+@_spi(Generated) import OpenAPIRuntime
 
 final class Test_ServerConverterExtensions: Test_Runtime {
 
@@ -92,26 +92,12 @@ final class Test_ServerConverterExtensions: Test_Runtime {
                     "Unexpected error when validating string: \(contentType) against headers: \(headers)"
                 )
             } else {
-                let acceptHeader =
-                    headers
-                    .values(name: "accept")
-                    .joined(separator: ", ")
                 XCTAssertThrowsError(
                     try converter.validateAcceptIfPresent(
                         contentType,
                         in: headers
                     ),
-                    "Expected to throw error when validating string: \(contentType) against headers: \(headers)",
-                    { error in
-                        guard
-                            let err = error as? RuntimeError,
-                            case .unexpectedAcceptHeader(let string) = err
-                        else {
-                            XCTFail("Threw an unexpected error: \(error)")
-                            return
-                        }
-                        XCTAssertEqual(string, acceptHeader)
-                    }
+                    "Expected to throw error when validating string: \(contentType) against headers: \(headers)"
                 )
             }
         }


### PR DESCRIPTION
### Motivation

In the previous PR, we missed one method which was supposed to be public, but was internal. Discovered while testing the generator, this this isn't being seen by users yet, but blocks us from rolling out the next 0.2.x generator.

### Modifications

Removed `@testable` (which made us miss it) from converter tests and made the missing method public.

### Result

Generated code should compile again.

### Test Plan

This PR is mostly about updating tests to catch this next time.
