### PR TITLE
Support base64-encoded data

### DIFF
--- a/Sources/OpenAPIRuntime/Base/Base64EncodedData.swift
+++ b/Sources/OpenAPIRuntime/Base/Base64EncodedData.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+public struct Base64EncodedData: Sendable, Codable, Hashable {
+    var data: Foundation.Data // or [UInt8] or ArraySlice<UInt8>
+
+    public init(data: Foundation.Data) {
+        self.data = data
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let base64EncodedString = try container.decode(String.self)
+        guard let data = Data(base64Encoded: base64EncodedString) else {
+            throw RuntimeError.invalidBase64String(base64EncodedString)
+        }
+        self.init(data: data)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        let base64String = data.base64EncodedString()
+        try container.encode(base64String)
+    }
+}

--- a/Sources/OpenAPIRuntime/Base/Base64EncodedData.swift
+++ b/Sources/OpenAPIRuntime/Base/Base64EncodedData.swift
@@ -81,7 +81,6 @@ extension Base64EncodedData: Codable {
         self.init(data: ArraySlice(data))
     }
 
-
     /// Encodes this value into the given encoder.
     ///
     /// If the value fails to encode anything, `encoder` will encode an empty

--- a/Sources/OpenAPIRuntime/Base/Base64EncodedData.swift
+++ b/Sources/OpenAPIRuntime/Base/Base64EncodedData.swift
@@ -32,7 +32,7 @@ import Foundation
 /// let base64EncodedData = Base64EncodedData(from: decoder)
 ///```
 ///
-/// However more commonly the decoding initializer would be called by a decoder e.g.
+/// However more commonly the decoding initializer would be called by a decoder, for example:
 /// ```swift
 /// let encodedData: Data = ...
 /// let decoded = try JSONDecoder().decode(Base64EncodedData.self, from: encodedData)
@@ -45,13 +45,13 @@ import Foundation
 /// base64EncodedData.encode(to: encoder)
 /// ```
 ///
-/// However more commonly it would be called by an encoder e.g.
+/// However more commonly it would be called by an encoder, for example:
 /// ```swift
 /// let bytes: ArraySlice<UInt8> = ...
 /// let encodedData = JSONEncoder().encode(encodedBytes)
 /// ```
 public struct Base64EncodedData: Sendable, Hashable {
-    /// data to be encoded
+    /// A container of the raw bytes.
     public var data: ArraySlice<UInt8>
 
     /// Initializes an instance of ``Base64EncodedData`` wrapping the provided slice of bytes.
@@ -62,12 +62,6 @@ public struct Base64EncodedData: Sendable, Hashable {
 }
 
 extension Base64EncodedData: Codable {
-    /// Creates a new instance by decoding from the given decoder.
-    ///
-    /// This initializer throws an error if reading from the decoder fails, or
-    /// if the data read is corrupted or otherwise invalid.
-    ///
-    /// - Parameter decoder: The decoder to read data from.
     public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         let base64EncodedString = try container.decode(String.self)
@@ -81,15 +75,6 @@ extension Base64EncodedData: Codable {
         self.init(data: ArraySlice(data))
     }
 
-    /// Encodes this value into the given encoder.
-    ///
-    /// If the value fails to encode anything, `encoder` will encode an empty
-    /// keyed container in its place.
-    ///
-    /// This function throws an error if any values are invalid for the given
-    /// encoder's format.
-    ///
-    /// - Parameter encoder: The encoder to write data to.
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
 

--- a/Sources/OpenAPIRuntime/Base/Base64EncodedData.swift
+++ b/Sources/OpenAPIRuntime/Base/Base64EncodedData.swift
@@ -14,13 +14,60 @@
 
 import Foundation
 
-public struct Base64EncodedData: Sendable, Codable, Hashable {
-    var data: ArraySlice<UInt8>
+/// Provides a route to encode or decode base64-encoded data
+///
+/// This type holds raw, unencoded, data as a slice of bytes. It can be used to encode that
+/// data to a provided `Encoder` as base64-encoded data or to decode from base64 encoding when
+/// initialized from a decoder.
+///
+/// There is a convenience initializer to create an instance backed by provided data in the form
+/// of a slice of bytes:
+/// ```swift
+/// let bytes: ArraySlice<UInt8> = ...
+/// let base64EncodedData = Base64EncodedData(data: bytes)
+/// ```
+///
+/// To decode base64-encoded data it is possible to call the initializer directly, providing a decoder:
+/// ```swift
+/// let base64EncodedData = Base64EncodedData(from: decoder)
+///```
+///
+/// However more commonly the decoding initializer would be called by a decoder e.g.
+/// ```swift
+/// let encodedData: Data = ...
+/// let decoded = try JSONDecoder().decode(Base64EncodedData.self, from: encodedData)
+///```
+///
+/// Once an instance is holding data, it may be base64 encoded to a provided encoder:
+/// ```swift
+/// let bytes: ArraySlice<UInt8> = ...
+/// let base64EncodedData = Base64EncodedData(data: bytes)
+/// base64EncodedData.encode(to: encoder)
+/// ```
+///
+/// However more commonly it would be called by an encoder e.g.
+/// ```swift
+/// let bytes: ArraySlice<UInt8> = ...
+/// let encodedData = JSONEncoder().encode(encodedBytes)
+/// ```
+public struct Base64EncodedData: Sendable, Hashable {
+    /// data to be encoded
+    public var data: ArraySlice<UInt8>
 
+    /// Initializes an instance of ``Base64EncodedData`` wrapping the provided slice of bytes.
+    /// - Parameter data: The underlying bytes to wrap.
     public init(data: ArraySlice<UInt8>) {
         self.data = data
     }
+}
 
+extension Base64EncodedData: Codable {
+    /// Creates a new instance by decoding from the given decoder.
+    ///
+    /// This initializer throws an error if reading from the decoder fails, or
+    /// if the data read is corrupted or otherwise invalid.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
     public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         let base64EncodedString = try container.decode(String.self)
@@ -34,6 +81,16 @@ public struct Base64EncodedData: Sendable, Codable, Hashable {
         self.init(data: ArraySlice(data))
     }
 
+
+    /// Encodes this value into the given encoder.
+    ///
+    /// If the value fails to encode anything, `encoder` will encode an empty
+    /// keyed container in its place.
+    ///
+    /// This function throws an error if any values are invalid for the given
+    /// encoder's format.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
 

--- a/Sources/OpenAPIRuntime/Base/Base64EncodedData.swift
+++ b/Sources/OpenAPIRuntime/Base/Base64EncodedData.swift
@@ -15,24 +15,35 @@
 import Foundation
 
 public struct Base64EncodedData: Sendable, Codable, Hashable {
-    var data: Foundation.Data // or [UInt8] or ArraySlice<UInt8>
+    var data: ArraySlice<UInt8>
 
-    public init(data: Foundation.Data) {
+    public init(data: ArraySlice<UInt8>) {
         self.data = data
     }
 
     public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         let base64EncodedString = try container.decode(String.self)
-        guard let data = Data(base64Encoded: base64EncodedString) else {
+
+        // permissive decoding
+        let options = Data.Base64DecodingOptions.ignoreUnknownCharacters
+
+        guard let data = Data(base64Encoded: base64EncodedString, options: options) else {
             throw RuntimeError.invalidBase64String(base64EncodedString)
         }
-        self.init(data: data)
+        self.init(data: ArraySlice(data))
     }
 
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
-        let base64String = data.base64EncodedString()
+
+        // https://datatracker.ietf.org/doc/html/rfc4648#section-3.1
+        // "Implementations MUST NOT add line feeds to base-encoded data unless
+        // the specification referring to this document explicitly directs base
+        // encoders to add line feeds after a specific number of characters."
+        let options = Data.Base64EncodingOptions()
+
+        let base64String = Data(data).base64EncodedString(options: options)
         try container.encode(base64String)
     }
 }

--- a/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
+++ b/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
@@ -75,7 +75,7 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
         case .invalidHeaderFieldName(let name):
             return "Invalid header field name: '\(name)'"
         case .invalidBase64String(let string):
-            return "Invalid base64-encoded string: '\(string)'"
+            return "Invalid base64-encoded string (first 128 bytes): '\(string.prefix(128))'"
         case .failedToDecodeStringConvertibleValue(let string):
             return "Failed to decode a value of type '\(string)'."
         case .unsupportedParameterStyle(name: let name, location: let location, style: let style, explode: let explode):

--- a/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
+++ b/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
@@ -21,6 +21,7 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
     case invalidServerURL(String)
     case invalidExpectedContentType(String)
     case invalidHeaderFieldName(String)
+    case invalidBase64String(String)
 
     // Data conversion
     case failedToDecodeStringConvertibleValue(type: String)
@@ -73,6 +74,8 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
             return "Invalid expected content type: '\(string)'"
         case .invalidHeaderFieldName(let name):
             return "Invalid header field name: '\(name)'"
+        case .invalidBase64String(let string):
+            return "Invalid base64-encoded string: '\(string)'"
         case .failedToDecodeStringConvertibleValue(let string):
             return "Failed to decode a value of type '\(string)'."
         case .unsupportedParameterStyle(name: let name, location: let location, style: let style, explode: let explode):

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -267,9 +267,27 @@ final class Test_OpenAPIValue: Test_Runtime {
         XCTAssertEqual(nestedValue, 2)
     }
 
-    func testEncodingDecodingRoundTrip_base64_success() throws {
-        print(String(data: testStructData.base64EncodedData(), encoding: .utf8)!.utf8)
-        let encodedData = Base64EncodedData(data: testStructData)
+    func testEncoding_base64_success() throws {
+        let encodedData = Base64EncodedData(data: ArraySlice(testStructData))
+
+        let JSONEncoded = try JSONEncoder().encode(encodedData)
+        XCTAssertEqual(String(data: JSONEncoded, encoding: .utf8)!, testStructBase64EncodedString)
+    }
+
+    func testDecoding_base64_success() throws {
+        let encodedData = Base64EncodedData(data: ArraySlice(testStructData))
+
+        // `testStructBase64EncodedString` quoted and base64-encoded again
+        let JSONEncoded = Data(base64Encoded: "ImV5SnVZVzFsSWpvaVJteDFabVo2SW4wPSI=")!
+
+        XCTAssertEqual(
+            try JSONDecoder().decode(Base64EncodedData.self, from: JSONEncoded),
+            encodedData
+        )
+    }
+
+    func testEncodingDecodingRoundtrip_base64_success() throws {
+        let encodedData = Base64EncodedData(data: ArraySlice(testStructData))
         XCTAssertEqual(
             try JSONDecoder().decode(Base64EncodedData.self, from: JSONEncoder().encode(encodedData)),
             encodedData

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-@_spi(Generated) @testable import OpenAPIRuntime
+@_spi(Generated)@testable import OpenAPIRuntime
 
 final class Test_OpenAPIValue: Test_Runtime {
 

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-@_spi(Generated) import OpenAPIRuntime
+@_spi(Generated) @testable import OpenAPIRuntime
 
 final class Test_OpenAPIValue: Test_Runtime {
 
@@ -265,5 +265,14 @@ final class Test_OpenAPIValue: Test_Runtime {
         let nestedDict = try XCTUnwrap(decoded.dict.value["nestedDict"] as? [String: Any?])
         let nestedValue = try XCTUnwrap(nestedDict["nested"] as? Int)
         XCTAssertEqual(nestedValue, 2)
+    }
+
+    func testEncodingDecodingRoundTrip_base64_success() throws {
+        print(String(data: testStructData.base64EncodedData(), encoding: .utf8)!.utf8)
+        let encodedData = Base64EncodedData(data: testStructData)
+        XCTAssertEqual(
+            try JSONDecoder().decode(Base64EncodedData.self, from: JSONEncoder().encode(encodedData)),
+            encodedData
+        )
     }
 }

--- a/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
+++ b/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
@@ -107,6 +107,10 @@ class Test_Runtime: XCTestCase {
         "age=3&name=Rover%21&type=Golden+Retriever"
     }
 
+    var testStructBase64EncodedString: String {
+        #""eyJuYW1lIjoiRmx1ZmZ6In0=""# // {"name":"Fluffz"}
+    }
+
     var testEnum: TestHabitat {
         .water
     }

--- a/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
+++ b/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
@@ -108,7 +108,7 @@ class Test_Runtime: XCTestCase {
     }
 
     var testStructBase64EncodedString: String {
-        #""eyJuYW1lIjoiRmx1ZmZ6In0=""# // {"name":"Fluffz"}
+        #""eyJuYW1lIjoiRmx1ZmZ6In0=""#  // {"name":"Fluffz"}
     }
 
     var testEnum: TestHabitat {


### PR DESCRIPTION
### Motivation

OpenAPI supports base64-encoded data but to this point OpenAPI Generator has not (https://github.com/apple/swift-openapi-generator/issues/11).

### Modifications

Introduce the `Base64EncodedData` codable type to allow users in the generator to describe byte types which must be en/de-coded.

### Result

Users will be able to describe base64-encoded data as `OpenAPIRuntime.Base64EncodedData` e.g.
```
public typealias MyData = OpenAPIRuntime.Base64EncodedData
```

### Test Plan

Added a round-trip encode/decode test `testEncodingDecodingRoundTrip_base64_success`
