### PR TITLE
Add SPIs for throwing RuntimeError from shorthand generated APIs

### DIFF
--- a/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
+++ b/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
@@ -55,6 +55,10 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
     case transportFailed(any Error)
     case handlerFailed(any Error)
 
+    // Unexpected response (thrown by shorthand APIs)
+    case unexpectedResponseStatus(expectedStatus: String, response: Any)
+    case unexpectedResponseBody(expectedContent: String, body: Any)
+
     // MARK: CustomStringConvertible
 
     var description: String {
@@ -96,6 +100,20 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
             return "Transport failed with error: \(underlyingError.localizedDescription)"
         case .handlerFailed(let underlyingError):
             return "User handler failed with error: \(underlyingError.localizedDescription)"
+        case .unexpectedResponseStatus(let expectedStatus, let response):
+            return "Unexpected response, expected status code: \(expectedStatus), response: \(response)"
+        case .unexpectedResponseBody(let expectedContentType, let response):
+            return "Unexpected response body, expected content type: \(expectedContentType), response: \(response)"
         }
     }
+}
+
+@_spi(Generated)
+public func throwUnexpectedResponseStatus(expectedStatus: String, response: Any) throws -> Never {
+    throw RuntimeError.unexpectedResponseStatus(expectedStatus: expectedStatus, response: response)
+}
+
+@_spi(Generated)
+public func throwUnexpectedResponseBody(expectedContent: String, body: Any) throws -> Never {
+    throw RuntimeError.unexpectedResponseBody(expectedContent: expectedContent, body: body)
 }

--- a/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
+++ b/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
@@ -56,8 +56,8 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
     case handlerFailed(any Error)
 
     // Unexpected response (thrown by shorthand APIs)
-    case unexpectedResponseStatus(expectedStatus: String, response: Any)
-    case unexpectedResponseBody(expectedContent: String, body: Any)
+    case unexpectedResponseStatus(expectedStatus: String, response: any Sendable)
+    case unexpectedResponseBody(expectedContent: String, body: any Sendable)
 
     // MARK: CustomStringConvertible
 
@@ -109,11 +109,11 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
 }
 
 @_spi(Generated)
-public func throwUnexpectedResponseStatus(expectedStatus: String, response: Any) throws -> Never {
+public func throwUnexpectedResponseStatus(expectedStatus: String, response: any Sendable) throws -> Never {
     throw RuntimeError.unexpectedResponseStatus(expectedStatus: expectedStatus, response: response)
 }
 
 @_spi(Generated)
-public func throwUnexpectedResponseBody(expectedContent: String, body: Any) throws -> Never {
+public func throwUnexpectedResponseBody(expectedContent: String, body: any Sendable) throws -> Never {
     throw RuntimeError.unexpectedResponseBody(expectedContent: expectedContent, body: body)
 }

--- a/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
+++ b/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
@@ -102,8 +102,8 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
             return "User handler failed with error: \(underlyingError.localizedDescription)"
         case .unexpectedResponseStatus(let expectedStatus, let response):
             return "Unexpected response, expected status code: \(expectedStatus), response: \(response)"
-        case .unexpectedResponseBody(let expectedContentType, let response):
-            return "Unexpected response body, expected content type: \(expectedContentType), response: \(response)"
+        case .unexpectedResponseBody(let expectedContentType, let body):
+            return "Unexpected response body, expected content type: \(expectedContentType), body: \(body)"
         }
     }
 }


### PR DESCRIPTION
### Motivation

The review period for SOAR-0007 (Shorthand APIs for inputs and outputs) has now concluded. This pull request adds the required SPIs to the runtime library to throw a runtime error when the response and/or body does not match that of the shorthand API being used.

For further context, please review the proposal itself.[^1] 

[^1]: https://github.com/apple/swift-openapi-generator/pull/291

### Modifications

- Extend `internal enum RuntimeError: Error` with two new cases:
    - `.unexpectedResponseStatus(expectedStatus:response:)`
    - `.unexpectedResponseBody(expectedContent:body:)`
- Add SPI for generated code, to throw these errors:
    - `@_spi(Generated) public throwUnexpectedResponseStatus(expectedStatus:response:)`
    - `@_spi(Generated) public throwUnexpectedResponseBody(expectedStatus:body:)`

### Result

Runtime library has two SPIs that can be used by the generator to implement the shorthand throwing getter APIs described in SOAR-0007.

### Test Plan

Companion PR in swift-openapi-generator. 