### PR TITLE
[Runtime] Support recursive types

### DIFF
--- a/Sources/OpenAPIRuntime/Base/CopyOnWriteBox.swift
+++ b/Sources/OpenAPIRuntime/Base/CopyOnWriteBox.swift
@@ -12,8 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A wrapper reference type for a value that should be copied only when
-/// referenced by multiple owners and is being modified.
+/// A reference type that wraps a value and enforces copy-on-write semantics.
 ///
 /// It also enables recursive types by introducing a "box" into the cycle, which
 /// allows the owning type to have a finite size.

--- a/Sources/OpenAPIRuntime/Base/CopyOnWriteBox.swift
+++ b/Sources/OpenAPIRuntime/Base/CopyOnWriteBox.swift
@@ -55,12 +55,31 @@ public final class CopyOnWriteBox<Wrapped> {
 }
 
 extension CopyOnWriteBox: Encodable where Wrapped: Encodable {
+
+    /// Encodes this value into the given encoder.
+    ///
+    /// If the value fails to encode anything, `encoder` will encode an empty
+    /// keyed container in its place.
+    ///
+    /// This function throws an error if any values are invalid for the given
+    /// encoder's format.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
+    /// - Throws: On an encoding error.
     public func encode(to encoder: any Encoder) throws {
         try value.encode(to: encoder)
     }
 }
 
 extension CopyOnWriteBox: Decodable where Wrapped: Decodable {
+
+    /// Creates a new instance by decoding from the given decoder.
+    ///
+    /// This initializer throws an error if reading from the decoder fails, or
+    /// if the data read is corrupted or otherwise invalid.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    /// - Throws: On a decoding error.
     public convenience init(from decoder: any Decoder) throws {
         let value = try Wrapped(from: decoder)
         self.init(value: value)
@@ -68,6 +87,16 @@ extension CopyOnWriteBox: Decodable where Wrapped: Decodable {
 }
 
 extension CopyOnWriteBox: Equatable where Wrapped: Equatable {
+
+    /// Returns a Boolean value indicating whether two values are equal.
+    ///
+    /// Equality is the inverse of inequality. For any values `a` and `b`,
+    /// `a == b` implies that `a != b` is `false`.
+    ///
+    /// - Parameters:
+    ///   - lhs: A value to compare.
+    ///   - rhs: Another value to compare.
+    /// - Returns: A Boolean value indicating whether the values are equal.
     public static func == (
         lhs: CopyOnWriteBox<Wrapped>,
         rhs: CopyOnWriteBox<Wrapped>
@@ -77,18 +106,82 @@ extension CopyOnWriteBox: Equatable where Wrapped: Equatable {
 }
 
 extension CopyOnWriteBox: Hashable where Wrapped: Hashable {
+
+    /// Hashes the essential components of this value by feeding them into the
+    /// given hasher.
+    ///
+    /// Implement this method to conform to the `Hashable` protocol. The
+    /// components used for hashing must be the same as the components compared
+    /// in your type's `==` operator implementation. Call `hasher.combine(_:)`
+    /// with each of these components.
+    ///
+    /// - Important: In your implementation of `hash(into:)`,
+    ///   don't call `finalize()` on the `hasher` instance provided,
+    ///   or replace it with a different instance.
+    ///   Doing so may become a compile-time error in the future.
+    ///
+    /// - Parameter hasher: The hasher to use when combining the components
+    ///   of this instance.
     public func hash(into hasher: inout Hasher) {
         hasher.combine(value)
     }
 }
 
 extension CopyOnWriteBox: CustomStringConvertible where Wrapped: CustomStringConvertible {
+
+    /// A textual representation of this instance.
+    ///
+    /// Calling this property directly is discouraged. Instead, convert an
+    /// instance of any type to a string by using the `String(describing:)`
+    /// initializer. This initializer works with any type, and uses the custom
+    /// `description` property for types that conform to
+    /// `CustomStringConvertible`:
+    ///
+    ///     struct Point: CustomStringConvertible {
+    ///         let x: Int, y: Int
+    ///
+    ///         var description: String {
+    ///             return "(\(x), \(y))"
+    ///         }
+    ///     }
+    ///
+    ///     let p = Point(x: 21, y: 30)
+    ///     let s = String(describing: p)
+    ///     print(s)
+    ///     // Prints "(21, 30)"
+    ///
+    /// The conversion of `p` to a string in the assignment to `s` uses the
+    /// `Point` type's `description` property.
     public var description: String {
         value.description
     }
 }
 
 extension CopyOnWriteBox: CustomDebugStringConvertible where Wrapped: CustomDebugStringConvertible {
+
+    /// A textual representation of this instance, suitable for debugging.
+    ///
+    /// Calling this property directly is discouraged. Instead, convert an
+    /// instance of any type to a string by using the `String(reflecting:)`
+    /// initializer. This initializer works with any type, and uses the custom
+    /// `debugDescription` property for types that conform to
+    /// `CustomDebugStringConvertible`:
+    ///
+    ///     struct Point: CustomDebugStringConvertible {
+    ///         let x: Int, y: Int
+    ///
+    ///         var debugDescription: String {
+    ///             return "(\(x), \(y))"
+    ///         }
+    ///     }
+    ///
+    ///     let p = Point(x: 21, y: 30)
+    ///     let s = String(reflecting: p)
+    ///     print(s)
+    ///     // Prints "(21, 30)"
+    ///
+    /// The conversion of `p` to a string in the assignment to `s` uses the
+    /// `Point` type's `debugDescription` property.
     public var debugDescription: String {
         value.debugDescription
     }

--- a/Sources/OpenAPIRuntime/Base/CopyOnWriteBox.swift
+++ b/Sources/OpenAPIRuntime/Base/CopyOnWriteBox.swift
@@ -20,28 +20,34 @@
 public struct CopyOnWriteBox<Wrapped> {
 
     /// The reference type storage for the box.
-    private final class Storage {
+    @usableFromInline
+    internal final class Storage {
 
         /// The stored value.
+        @usableFromInline
         var value: Wrapped
 
         /// Creates a new storage with the provided initial value.
         /// - Parameter value: The initial value to store in the box.
+        @usableFromInline
         init(value: Wrapped) {
             self.value = value
         }
     }
 
     /// The internal storage of the box.
-    private var storage: Storage
+    @usableFromInline
+    internal var storage: Storage
 
     /// Creates a new box.
     /// - Parameter value: The value to store in the box.
+    @inlinable
     public init(value: Wrapped) {
         self.storage = .init(value: value)
     }
 
     /// The stored value whose accessors enforce copy-on-write semantics.
+    @inlinable
     public var value: Wrapped {
         get {
             storage.value

--- a/Sources/OpenAPIRuntime/Base/CopyOnWriteBox.swift
+++ b/Sources/OpenAPIRuntime/Base/CopyOnWriteBox.swift
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A wrapper reference type for a value that should be copied only when
+/// referenced by multiple owners and is being modified.
+///
+/// It also enables recursive types by introducing a "box" into the cycle, which
+/// allows the owning type to have a finite size.
+@_spi(Generated)
+public final class CopyOnWriteBox<Wrapped> {
+
+    /// The stored value.
+    private var value: Wrapped
+
+    /// Creates a new box.
+    /// - Parameter value: The value to store in the box.
+    public init(value: Wrapped) {
+        self.value = value
+    }
+
+    /// Returns a copy of the stored value.
+    public func read() -> Wrapped {
+        value
+    }
+
+    /// Provides read-write access to the stored value and enforces
+    /// copy-on-write semantics.
+    /// - Parameters:
+    ///   - box: A reference to the existing box, into which a new reference
+    ///     might get written if a copy had to be made.
+    ///   - modify: The closure that modifies the value.
+    public static func write(
+        to box: inout CopyOnWriteBox<Wrapped>,
+        using modify: (inout Wrapped) -> Void
+    ) {
+        let resolvedBox: CopyOnWriteBox<Wrapped>
+        if isKnownUniquelyReferenced(&box) {
+            resolvedBox = box
+        } else {
+            resolvedBox = Self(value: box.value)
+            box = resolvedBox
+        }
+        modify(&resolvedBox.value)
+    }
+}
+
+extension CopyOnWriteBox: Encodable where Wrapped: Encodable {
+    public func encode(to encoder: any Encoder) throws {
+        try value.encode(to: encoder)
+    }
+}
+
+extension CopyOnWriteBox: Decodable where Wrapped: Decodable {
+    public convenience init(from decoder: any Decoder) throws {
+        let value = try Wrapped(from: decoder)
+        self.init(value: value)
+    }
+}
+
+extension CopyOnWriteBox: Equatable where Wrapped: Equatable {
+    public static func == (
+        lhs: CopyOnWriteBox<Wrapped>,
+        rhs: CopyOnWriteBox<Wrapped>
+    ) -> Bool {
+        lhs.value == rhs.value
+    }
+}
+
+extension CopyOnWriteBox: Hashable where Wrapped: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(value)
+    }
+}
+
+extension CopyOnWriteBox: CustomStringConvertible where Wrapped: CustomStringConvertible {
+    public var description: String {
+        value.description
+    }
+}
+
+extension CopyOnWriteBox: CustomDebugStringConvertible where Wrapped: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        value.debugDescription
+    }
+}
+
+extension CopyOnWriteBox: @unchecked Sendable where Wrapped: Sendable {}

--- a/Sources/OpenAPIRuntime/Base/CopyOnWriteBox.swift
+++ b/Sources/OpenAPIRuntime/Base/CopyOnWriteBox.swift
@@ -29,7 +29,7 @@ public struct CopyOnWriteBox<Wrapped> {
 
         /// Creates a new storage with the provided initial value.
         /// - Parameter value: The initial value to store in the box.
-        @usableFromInline
+        @inlinable
         init(value: Wrapped) {
             self.value = value
         }
@@ -73,6 +73,7 @@ extension CopyOnWriteBox: Encodable where Wrapped: Encodable {
     ///
     /// - Parameter encoder: The encoder to write data to.
     /// - Throws: On an encoding error.
+    @inlinable
     public func encode(to encoder: any Encoder) throws {
         try value.encode(to: encoder)
     }
@@ -87,6 +88,7 @@ extension CopyOnWriteBox: Decodable where Wrapped: Decodable {
     ///
     /// - Parameter decoder: The decoder to read data from.
     /// - Throws: On a decoding error.
+    @inlinable
     public init(from decoder: any Decoder) throws {
         let value = try Wrapped(from: decoder)
         self.init(value: value)
@@ -104,6 +106,7 @@ extension CopyOnWriteBox: Equatable where Wrapped: Equatable {
     ///   - lhs: A value to compare.
     ///   - rhs: Another value to compare.
     /// - Returns: A Boolean value indicating whether the values are equal.
+    @inlinable
     public static func == (
         lhs: CopyOnWriteBox<Wrapped>,
         rhs: CopyOnWriteBox<Wrapped>
@@ -129,6 +132,7 @@ extension CopyOnWriteBox: Hashable where Wrapped: Hashable {
     ///
     /// - Parameter hasher: The hasher to use when combining the components
     ///   of this instance.
+    @inlinable
     public func hash(into hasher: inout Hasher) {
         hasher.combine(value)
     }
@@ -159,6 +163,7 @@ extension CopyOnWriteBox: CustomStringConvertible where Wrapped: CustomStringCon
     ///
     /// The conversion of `p` to a string in the assignment to `s` uses the
     /// `Point` type's `description` property.
+    @inlinable
     public var description: String {
         value.description
     }
@@ -189,6 +194,7 @@ extension CopyOnWriteBox: CustomDebugStringConvertible where Wrapped: CustomDebu
     ///
     /// The conversion of `p` to a string in the assignment to `s` uses the
     /// `Point` type's `debugDescription` property.
+    @inlinable
     public var debugDescription: String {
         value.debugDescription
     }

--- a/Tests/OpenAPIRuntimeTests/Base/Test_CopyOnWriteBox.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_CopyOnWriteBox.swift
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+@_spi(Generated) import OpenAPIRuntime
+
+final class Test_CopyOnWriteBox: Test_Runtime {
+
+    struct Node: Codable, Equatable {
+        var id: Int
+        var parent: CopyOnWriteBox<Node>?
+    }
+
+    func testModification() throws {
+        var value = Node(
+            id: 3,
+            parent: .init(
+                value: .init(
+                    id: 2
+                )
+            )
+        )
+        XCTAssertEqual(
+            value,
+            Node(
+                id: 3,
+                parent: .init(
+                    value: .init(
+                        id: 2
+                    )
+                )
+            )
+        )
+        CopyOnWriteBox.write(to: &value.parent!) { wrapped in
+            wrapped = .init(id: 1)
+        }
+        XCTAssertEqual(
+            value,
+            Node(
+                id: 3,
+                parent: .init(
+                    value: .init(
+                        id: 2,
+                        parent: .init(
+                            value: .init(id: 1)
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    func testSerialization() throws {
+        let value = CopyOnWriteBox(value: "Hello")
+        try testRoundtrip(
+            value,
+            expectedJSON: #""Hello""#
+        )
+    }
+
+    func testIntegration() throws {
+        let value = Node(
+            id: 3,
+            parent: .init(
+                value: .init(
+                    id: 2,
+                    parent: .init(
+                        value: .init(id: 1)
+                    )
+                )
+            )
+        )
+        try testRoundtrip(
+            value,
+            expectedJSON: #"""
+                {
+                  "id" : 3,
+                  "parent" : {
+                    "id" : 2,
+                    "parent" : {
+                      "id" : 1
+                    }
+                  }
+                }
+                """#
+        )
+    }
+}

--- a/Tests/OpenAPIRuntimeTests/Base/Test_CopyOnWriteBox.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_CopyOnWriteBox.swift
@@ -42,7 +42,7 @@ final class Test_CopyOnWriteBox: Test_Runtime {
             )
         )
         CopyOnWriteBox.write(to: &value.parent!) { wrapped in
-            wrapped = .init(id: 1)
+            wrapped.parent = .init(value: .init(id: 1))
         }
         XCTAssertEqual(
             value,

--- a/Tests/OpenAPIRuntimeTests/Base/Test_CopyOnWriteBox.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_CopyOnWriteBox.swift
@@ -41,9 +41,7 @@ final class Test_CopyOnWriteBox: Test_Runtime {
                 )
             )
         )
-        CopyOnWriteBox.write(to: &value.parent!) { wrapped in
-            wrapped.parent = .init(value: .init(id: 1))
-        }
+        value.parent!.value.parent = .init(value: .init(id: 1))
         XCTAssertEqual(
             value,
             Node(

--- a/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
+++ b/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
@@ -131,17 +131,26 @@ class Test_Runtime: XCTestCase {
         Data(testStructURLFormString.utf8)
     }
 
-    func _testPrettyEncoded<Value: Encodable>(_ value: Value, expectedJSON: String) throws {
+    @discardableResult
+    func _testPrettyEncoded<Value: Encodable>(_ value: Value, expectedJSON: String) throws -> String {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(value)
-        XCTAssertEqual(String(data: data, encoding: .utf8)!, expectedJSON)
+        let encodedString = String(decoding: data, as: UTF8.self)
+        XCTAssertEqual(encodedString, expectedJSON)
+        return encodedString
     }
 
     func _getDecoded<Value: Decodable>(json: String) throws -> Value {
         let inputData = json.data(using: .utf8)!
         let decoder = JSONDecoder()
         return try decoder.decode(Value.self, from: inputData)
+    }
+
+    func testRoundtrip<Value: Codable & Equatable>(_ value: Value, expectedJSON: String) throws {
+        let encodedString = try _testPrettyEncoded(value, expectedJSON: expectedJSON)
+        let decoded: Value = try _getDecoded(json: encodedString)
+        XCTAssertEqual(decoded, value)
     }
 }
 


### PR DESCRIPTION
### Motivation

Runtime changes for https://github.com/apple/swift-openapi-generator/issues/70.

### Modifications

Introduce a new wrapper type `CopyOnWriteBox` as a reference type with copy-on-write semantics, to be used by the generated code to hide a ref type inside a struct that needs boxing. (Details on the logic will be in the generator PR description.)

### Result

A new type available for the generated code to use for breaking reference cycles.

### Test Plan

Added unit tests for the type.
