### PR TITLE
Bump swift-format to 5.9

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/ParameterStyles.swift
+++ b/Sources/OpenAPIRuntime/Conversion/ParameterStyles.swift
@@ -45,6 +45,7 @@ extension ParameterStyle {
 
     /// Returns the default value of the explode field for the given style
     /// - Parameter style: The parameter style.
+    /// - Returns: The explode value.
     static func defaultExplodeFor(forStyle style: ParameterStyle) -> Bool {
         style == .form
     }

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-@_spi(Generated)@testable import OpenAPIRuntime
+@_spi(Generated) @testable import OpenAPIRuntime
 
 final class Test_OpenAPIValue: Test_Runtime {
 

--- a/Tests/OpenAPIRuntimeTests/Deprecated/Test_Deprecated.swift
+++ b/Tests/OpenAPIRuntimeTests/Deprecated/Test_Deprecated.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-@_spi(Generated)@testable import OpenAPIRuntime
+@_spi(Generated) @testable import OpenAPIRuntime
 
 final class Test_Deprecated: Test_Runtime {
     // Tests for deprecated code goes here.

--- a/Tests/OpenAPIRuntimeTests/Interface/Test_HTTPBody.swift
+++ b/Tests/OpenAPIRuntimeTests/Interface/Test_HTTPBody.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-@_spi(Generated)@testable import OpenAPIRuntime
+@_spi(Generated) @testable import OpenAPIRuntime
 import Foundation
 
 final class Test_Body: Test_Runtime {

--- a/Tests/OpenAPIRuntimeTests/Interface/Test_UniversalServer.swift
+++ b/Tests/OpenAPIRuntimeTests/Interface/Test_UniversalServer.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-@_spi(Generated)@testable import OpenAPIRuntime
+@_spi(Generated) @testable import OpenAPIRuntime
 
 final class Test_UniversalServer: Test_Runtime {
 

--- a/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
+++ b/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
@@ -18,6 +18,7 @@ import HTTPTypes
 
 class Test_Runtime: XCTestCase {
 
+    /// Setup method called before the invocation of each test method in the class.
     override func setUp() async throws {
         try await super.setUp()
         continueAfterFailure = false

--- a/Tests/OpenAPIRuntimeTests/URICoder/Test_URICodingRoundtrip.swift
+++ b/Tests/OpenAPIRuntimeTests/URICoder/Test_URICodingRoundtrip.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-@_spi(Generated)@testable import OpenAPIRuntime
+@_spi(Generated) @testable import OpenAPIRuntime
 #if os(Linux)
 @preconcurrency import Foundation
 #endif

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p $HOME/.tools
 RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
 
 # swift-format
-ARG swiftformat_version=508.0.0
+ARG swiftformat_version=509.0.0
 RUN git clone --branch $swiftformat_version --depth 1 https://github.com/apple/swift-format $HOME/.tools/swift-format-source
 RUN cd $HOME/.tools/swift-format-source && swift build -c release
 RUN ln -s $HOME/.tools/swift-format-source/.build/release/swift-format $HOME/.tools/swift-format


### PR DESCRIPTION
### Motivation

Let's move to swift-format 5.9, as per https://github.com/apple/swift-openapi-generator/issues/175.

### Modifications

Bump to 5.9 and update code to pass, also update the Dockerfile for Linux CI.

### Result

Uses swift-format 5.9.

### Test Plan

Soundness passed.
