### PR TITLE
Improved enriched error propagation from the transport and middlewares

### DIFF
--- a/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
+++ b/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
@@ -12,5 +12,91 @@
 //
 //===----------------------------------------------------------------------===//
 import Foundation
+import HTTPTypes
 
 // MARK: - Functionality to be removed in the future
+
+extension ClientError {
+    /// Creates a new error.
+    /// - Parameters:
+    ///   - operationID: The OpenAPI operation identifier.
+    ///   - operationInput: The operation-specific Input value.
+    ///   - request: The HTTP request created during the operation.
+    ///   - requestBody: The HTTP request body created during the operation.
+    ///   - baseURL: The base URL for HTTP requests.
+    ///   - response: The HTTP response received during the operation.
+    ///   - responseBody: The HTTP response body received during the operation.
+    ///   - underlyingError: The underlying error that caused the operation
+    ///     to fail.
+    @available(
+        *,
+        deprecated,
+        renamed:
+            "ClientError.init(operationID:operationInput:request:requestBody:baseURL:response:responseBody:causeDescription:underlyingError:)",
+        message: "Use the initializer with a causeDescription parameter."
+    )
+    public init(
+        operationID: String,
+        operationInput: any Sendable,
+        request: HTTPRequest? = nil,
+        requestBody: HTTPBody? = nil,
+        baseURL: URL? = nil,
+        response: HTTPResponse? = nil,
+        responseBody: HTTPBody? = nil,
+        underlyingError: any Error
+    ) {
+        self.init(
+            operationID: operationID,
+            operationInput: operationInput,
+            request: request,
+            requestBody: requestBody,
+            baseURL: baseURL,
+            response: response,
+            responseBody: responseBody,
+            causeDescription: "Legacy error without a causeDescription.",
+            underlyingError: underlyingError
+        )
+    }
+}
+
+extension ServerError {
+    /// Creates a new error.
+    /// - Parameters:
+    ///   - operationID: The OpenAPI operation identifier.
+    ///   - request: The HTTP request provided to the server.
+    ///   - requestBody: The HTTP request body provided to the server.
+    ///   - requestMetadata: The request metadata extracted by the server.
+    ///   - operationInput: An operation-specific Input value.
+    ///   - operationOutput: An operation-specific Output value.
+    ///   - causeDescription: A user-facing description of what caused
+    ///     the underlying error to be thrown.
+    ///   - underlyingError: The underlying error that caused the operation
+    ///     to fail.
+    @available(
+        *,
+        deprecated,
+        renamed:
+            "ServerError.init(operationID:request:requestBody:requestMetadata:operationInput:operationOutput:causeDescription:underlyingError:)",
+        message: "Use the initializer with a causeDescription parameter."
+    )
+    public init(
+        operationID: String,
+        request: HTTPRequest,
+        requestBody: HTTPBody?,
+        requestMetadata: ServerRequestMetadata,
+        operationInput: (any Sendable)? = nil,
+        operationOutput: (any Sendable)? = nil,
+        underlyingError: any Error
+    ) {
+        self.init(
+            operationID: operationID,
+            request: request,
+            requestBody: requestBody,
+            requestMetadata: requestMetadata,
+            operationInput: operationInput,
+            operationOutput: operationOutput,
+            causeDescription: "Legacy error without a causeDescription.",
+            underlyingError: underlyingError
+        )
+    }
+}

--- a/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
+++ b/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
@@ -68,8 +68,6 @@ extension ServerError {
     ///   - requestMetadata: The request metadata extracted by the server.
     ///   - operationInput: An operation-specific Input value.
     ///   - operationOutput: An operation-specific Output value.
-    ///   - causeDescription: A user-facing description of what caused
-    ///     the underlying error to be thrown.
     ///   - underlyingError: The underlying error that caused the operation
     ///     to fail.
     @available(

--- a/Sources/OpenAPIRuntime/Errors/ClientError.swift
+++ b/Sources/OpenAPIRuntime/Errors/ClientError.swift
@@ -64,6 +64,10 @@ public struct ClientError: Error {
     /// Will be nil if the error resulted before the response was received.
     public var responseBody: HTTPBody?
 
+    /// A user-facing description of what caused the underlying error
+    /// to be thrown.
+    public var causeDescription: String
+
     /// The underlying error that caused the operation to fail.
     public var underlyingError: any Error
 
@@ -76,6 +80,8 @@ public struct ClientError: Error {
     ///   - baseURL: The base URL for HTTP requests.
     ///   - response: The HTTP response received during the operation.
     ///   - responseBody: The HTTP response body received during the operation.
+    ///   - causeDescription: A user-facing description of what caused
+    ///     the underlying error to be thrown.
     ///   - underlyingError: The underlying error that caused the operation
     ///     to fail.
     public init(
@@ -86,6 +92,7 @@ public struct ClientError: Error {
         baseURL: URL? = nil,
         response: HTTPResponse? = nil,
         responseBody: HTTPBody? = nil,
+        causeDescription: String,
         underlyingError: any Error
     ) {
         self.operationID = operationID
@@ -95,6 +102,7 @@ public struct ClientError: Error {
         self.baseURL = baseURL
         self.response = response
         self.responseBody = responseBody
+        self.causeDescription = causeDescription
         self.underlyingError = underlyingError
     }
 
@@ -115,7 +123,7 @@ extension ClientError: CustomStringConvertible {
     ///
     /// - Returns: A string describing the client error and its associated details.
     public var description: String {
-        "Client error - operationID: \(operationID), operationInput: \(String(describing: operationInput)), request: \(request?.prettyDescription ?? "<nil>"), requestBody: \(requestBody?.prettyDescription ?? "<nil>"), baseURL: \(baseURL?.absoluteString ?? "<nil>"), response: \(response?.prettyDescription ?? "<nil>"), responseBody: \(responseBody?.prettyDescription ?? "<nil>") , underlying error: \(underlyingErrorDescription)"
+        "Client error - cause description: '\(causeDescription)', underlying error: \(underlyingErrorDescription), operationID: \(operationID), operationInput: \(String(describing: operationInput)), request: \(request?.prettyDescription ?? "<nil>"), requestBody: \(requestBody?.prettyDescription ?? "<nil>"), baseURL: \(baseURL?.absoluteString ?? "<nil>"), response: \(response?.prettyDescription ?? "<nil>"), responseBody: \(responseBody?.prettyDescription ?? "<nil>")"
     }
 }
 

--- a/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
+++ b/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
@@ -64,10 +64,9 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
     /// A wrapped root cause error, if one was thrown by other code.
     var underlyingError: (any Error)? {
         switch self {
-        case
-                .transportFailed(let error),
-                .handlerFailed(let error),
-                .middlewareFailed(_, let error):
+        case .transportFailed(let error),
+            .handlerFailed(let error),
+            .middlewareFailed(_, let error):
             return error
         default:
             return nil

--- a/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
+++ b/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
@@ -54,6 +54,7 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
 
     // Transport/Handler
     case transportFailed(any Error)
+    case middlewareFailed(middlewareType: Any.Type, any Error)
     case handlerFailed(any Error)
 
     // Unexpected response (thrown by shorthand APIs)
@@ -63,7 +64,10 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
     /// A wrapped root cause error, if one was thrown by other code.
     var underlyingError: (any Error)? {
         switch self {
-        case .transportFailed(let error), .handlerFailed(let error):
+        case
+                .transportFailed(let error),
+                .handlerFailed(let error),
+                .middlewareFailed(_, let error):
             return error
         default:
             return nil
@@ -111,6 +115,8 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
             return "Missing required response body"
         case .transportFailed:
             return "Transport threw an error."
+        case .middlewareFailed(middlewareType: let type, _):
+            return "Middleware of type '\(type)' threw an error."
         case .handlerFailed:
             return "User handler threw an error."
         case .unexpectedResponseStatus(let expectedStatus, let response):

--- a/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
+++ b/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
@@ -60,6 +60,16 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
     case unexpectedResponseStatus(expectedStatus: String, response: any Sendable)
     case unexpectedResponseBody(expectedContent: String, body: any Sendable)
 
+    /// A wrapped root cause error, if one was thrown by other code.
+    var underlyingError: (any Error)? {
+        switch self {
+        case .transportFailed(let error), .handlerFailed(let error):
+            return error
+        default:
+            return nil
+        }
+    }
+
     // MARK: CustomStringConvertible
 
     var description: String {
@@ -99,10 +109,10 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
             return "Missing required request body"
         case .missingRequiredResponseBody:
             return "Missing required response body"
-        case .transportFailed(let underlyingError):
-            return "Transport failed with error: \(underlyingError.localizedDescription)"
-        case .handlerFailed(let underlyingError):
-            return "User handler failed with error: \(underlyingError.localizedDescription)"
+        case .transportFailed:
+            return "Transport threw an error."
+        case .handlerFailed:
+            return "User handler threw an error."
         case .unexpectedResponseStatus(let expectedStatus, let response):
             return "Unexpected response, expected status code: \(expectedStatus), response: \(response)"
         case .unexpectedResponseBody(let expectedContentType, let body):

--- a/Sources/OpenAPIRuntime/Errors/ServerError.swift
+++ b/Sources/OpenAPIRuntime/Errors/ServerError.swift
@@ -40,6 +40,10 @@ public struct ServerError: Error {
     /// Is nil if error was thrown before/during Output -> response conversion.
     public var operationOutput: (any Sendable)?
 
+    /// A user-facing description of what caused the underlying error
+    /// to be thrown.
+    public var causeDescription: String
+
     /// The underlying error that caused the operation to fail.
     public var underlyingError: any Error
 
@@ -51,6 +55,8 @@ public struct ServerError: Error {
     ///   - requestMetadata: The request metadata extracted by the server.
     ///   - operationInput: An operation-specific Input value.
     ///   - operationOutput: An operation-specific Output value.
+    ///   - causeDescription: A user-facing description of what caused
+    ///     the underlying error to be thrown.
     ///   - underlyingError: The underlying error that caused the operation
     ///     to fail.
     public init(
@@ -60,7 +66,8 @@ public struct ServerError: Error {
         requestMetadata: ServerRequestMetadata,
         operationInput: (any Sendable)? = nil,
         operationOutput: (any Sendable)? = nil,
-        underlyingError: (any Error)
+        causeDescription: String,
+        underlyingError: any Error
     ) {
         self.operationID = operationID
         self.request = request
@@ -68,6 +75,7 @@ public struct ServerError: Error {
         self.requestMetadata = requestMetadata
         self.operationInput = operationInput
         self.operationOutput = operationOutput
+        self.causeDescription = causeDescription
         self.underlyingError = underlyingError
     }
 
@@ -88,7 +96,7 @@ extension ServerError: CustomStringConvertible {
     ///
     /// - Returns: A string describing the server error and its associated details.
     public var description: String {
-        "Server error - operationID: \(operationID), request: \(request.prettyDescription), requestBody: \(requestBody?.prettyDescription ?? "<nil>"), metadata: \(requestMetadata.description), operationInput: \(operationInput.map { String(describing: $0) } ?? "<nil>"), operationOutput: \(operationOutput.map { String(describing: $0) } ?? "<nil>"), underlying error: \(underlyingErrorDescription)"
+        "Server error - cause description: '\(causeDescription)', underlying error: \(underlyingErrorDescription), operationID: \(operationID), request: \(request.prettyDescription), requestBody: \(requestBody?.prettyDescription ?? "<nil>"), metadata: \(requestMetadata.description), operationInput: \(operationInput.map { String(describing: $0) } ?? "<nil>"), operationOutput: \(operationOutput.map { String(describing: $0) } ?? "<nil>")"
     }
 }
 

--- a/Sources/OpenAPIRuntime/Interface/UniversalServer.swift
+++ b/Sources/OpenAPIRuntime/Interface/UniversalServer.swift
@@ -119,14 +119,24 @@ import struct Foundation.URLComponents
             output: OperationOutput? = nil,
             error: any Error
         ) -> any Error {
-            ServerError(
+            let causeDescription: String
+            let underlyingError: any Error
+            if let runtimeError = error as? RuntimeError {
+                causeDescription = runtimeError.prettyDescription
+                underlyingError = runtimeError.underlyingError ?? error
+            } else {
+                causeDescription = "Unknown"
+                underlyingError = error
+            }
+            return ServerError(
                 operationID: operationID,
                 request: request,
                 requestBody: requestBody,
                 requestMetadata: metadata,
                 operationInput: input,
                 operationOutput: output,
-                underlyingError: error
+                causeDescription: causeDescription,
+                underlyingError: underlyingError
             )
         }
         var next: @Sendable (HTTPRequest, HTTPBody?, ServerRequestMetadata) async throws -> (HTTPResponse, HTTPBody?) =

--- a/Tests/OpenAPIRuntimeTests/Interface/Test_UniversalClient.swift
+++ b/Tests/OpenAPIRuntimeTests/Interface/Test_UniversalClient.swift
@@ -1,0 +1,154 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import HTTPTypes
+import Foundation
+@_spi(Generated) @testable import OpenAPIRuntime
+
+struct MockClientTransport: ClientTransport {
+    var sendBlock: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
+    func send(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        baseURL: URL,
+        operationID: String
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        try await sendBlock(request, body, baseURL, operationID)
+    }
+
+    static let requestBody: HTTPBody = HTTPBody("hello")
+    static let responseBody: HTTPBody = HTTPBody("bye")
+
+    static var successful: Self {
+        MockClientTransport { _, _, _, _ in
+            (HTTPResponse(status: .ok), responseBody)
+        }
+    }
+
+    static var failing: Self {
+        MockClientTransport { _, _, _, _ in
+            throw TestError()
+        }
+    }
+}
+
+final class Test_UniversalClient: Test_Runtime {
+
+    func testSuccess() async throws {
+        let client = UniversalClient(transport: MockClientTransport.successful)
+        let output = try await client.send(
+            input: "input",
+            forOperation: "op",
+            serializer: { input in
+                (
+                    HTTPRequest(soar_path: "/", method: .post),
+                    MockClientTransport.requestBody
+                )
+            },
+            deserializer: { response, body in
+                let body = try XCTUnwrap(body)
+                let string = try await String(collecting: body, upTo: 10)
+                return string
+            }
+        )
+        XCTAssertEqual(output, "bye")
+    }
+
+    func testErrorPropagation_serializer() async throws {
+        do {
+            let client = UniversalClient(transport: MockClientTransport.successful)
+            try await client.send(
+                input: "input",
+                forOperation: "op",
+                serializer: { input in
+                    throw TestError()
+                },
+                deserializer: { response, body in
+                    fatalError()
+                }
+            )
+        } catch {
+            let clientError = try XCTUnwrap(error as? ClientError)
+            XCTAssertEqual(clientError.operationID, "op")
+            XCTAssertEqual(clientError.operationInput as? String, "input")
+            XCTAssertEqual(clientError.causeDescription, "Unknown")
+            XCTAssertEqual(clientError.underlyingError as? TestError, TestError())
+            XCTAssertNil(clientError.request)
+            XCTAssertNil(clientError.requestBody)
+            XCTAssertNil(clientError.baseURL)
+            XCTAssertNil(clientError.response)
+            XCTAssertNil(clientError.responseBody)
+        }
+    }
+
+    func testErrorPropagation_transport() async throws {
+        do {
+            let client = UniversalClient(transport: MockClientTransport.failing)
+            try await client.send(
+                input: "input",
+                forOperation: "op",
+                serializer: { input in
+                    (
+                        HTTPRequest(soar_path: "/", method: .post),
+                        MockClientTransport.requestBody
+                    )
+                },
+                deserializer: { response, body in
+                    fatalError()
+                }
+            )
+        } catch {
+            let clientError = try XCTUnwrap(error as? ClientError)
+            XCTAssertEqual(clientError.operationID, "op")
+            XCTAssertEqual(clientError.operationInput as? String, "input")
+            XCTAssertEqual(clientError.causeDescription, "Transport threw an error.")
+            XCTAssertEqual(clientError.underlyingError as? TestError, TestError())
+            XCTAssertEqual(clientError.request, HTTPRequest(soar_path: "/", method: .post))
+            XCTAssertEqual(clientError.requestBody, MockClientTransport.requestBody)
+            XCTAssertEqual(clientError.baseURL, URL(string: "/"))
+            XCTAssertNil(clientError.response)
+            XCTAssertNil(clientError.responseBody)
+        }
+    }
+
+    func testErrorPropagation_deserializer() async throws {
+        do {
+            let client = UniversalClient(transport: MockClientTransport.successful)
+            try await client.send(
+                input: "input",
+                forOperation: "op",
+                serializer: { input in
+                    (
+                        HTTPRequest(soar_path: "/", method: .post),
+                        MockClientTransport.requestBody
+                    )
+                },
+                deserializer: { response, body in
+                    throw TestError()
+                }
+            )
+        } catch {
+            let clientError = try XCTUnwrap(error as? ClientError)
+            XCTAssertEqual(clientError.operationID, "op")
+            XCTAssertEqual(clientError.operationInput as? String, "input")
+            XCTAssertEqual(clientError.causeDescription, "Unknown")
+            XCTAssertEqual(clientError.underlyingError as? TestError, TestError())
+            XCTAssertEqual(clientError.request, HTTPRequest(soar_path: "/", method: .post))
+            XCTAssertEqual(clientError.requestBody, MockClientTransport.requestBody)
+            XCTAssertEqual(clientError.baseURL, URL(string: "/"))
+            XCTAssertEqual(clientError.response, HTTPResponse(status: .ok))
+            XCTAssertEqual(clientError.responseBody, MockClientTransport.responseBody)
+        }
+    }
+}

--- a/Tests/OpenAPIRuntimeTests/Interface/Test_UniversalClient.swift
+++ b/Tests/OpenAPIRuntimeTests/Interface/Test_UniversalClient.swift
@@ -91,7 +91,7 @@ final class Test_UniversalClient: Test_Runtime {
             XCTAssertNil(clientError.responseBody)
         }
     }
-    
+
     func testErrorPropagation_middlewareOnRequest() async throws {
         do {
             let client = UniversalClient(
@@ -192,8 +192,8 @@ final class Test_UniversalClient: Test_Runtime {
             XCTAssertEqual(clientError.request, HTTPRequest(soar_path: "/", method: .post))
             XCTAssertEqual(clientError.requestBody, MockClientTransport.requestBody)
             XCTAssertEqual(clientError.baseURL, URL(string: "/"))
-            XCTAssertEqual(clientError.response, HTTPResponse(status: .ok))
-            XCTAssertEqual(clientError.responseBody, MockClientTransport.responseBody)
+            XCTAssertNil(clientError.response)
+            XCTAssertNil(clientError.responseBody)
         }
     }
 

--- a/Tests/OpenAPIRuntimeTests/Interface/Test_UniversalServer.swift
+++ b/Tests/OpenAPIRuntimeTests/Interface/Test_UniversalServer.swift
@@ -12,11 +12,136 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
+import HTTPTypes
+import Foundation
 @_spi(Generated) @testable import OpenAPIRuntime
+
+struct MockHandler: Sendable {
+    var shouldFail: Bool = false
+    func greet(_ input: String) async throws -> String {
+        if shouldFail {
+            throw TestError()
+        }
+        guard input == "hello" else {
+            throw TestError()
+        }
+        return "bye"
+    }
+
+    static let requestBody: HTTPBody = HTTPBody("hello")
+    static let responseBody: HTTPBody = HTTPBody("bye")
+}
 
 final class Test_UniversalServer: Test_Runtime {
 
-    struct MockHandler: Sendable {}
+    func testSuccess() async throws {
+        let server = UniversalServer(handler: MockHandler())
+        let (response, responseBody) = try await server.handle(
+            request: .init(soar_path: "/", method: .post),
+            requestBody: .init("hello"),
+            metadata: .init(),
+            forOperation: "op",
+            using: { MockHandler.greet($0) },
+            deserializer: { request, body, metadata in
+                let body = try XCTUnwrap(body)
+                return try await String(collecting: body, upTo: 10)
+            },
+            serializer: { output, _ in
+                (HTTPResponse(status: .ok), MockHandler.responseBody)
+            }
+        )
+        XCTAssertEqual(response, HTTPResponse(status: .ok))
+        XCTAssertEqual(responseBody, MockHandler.responseBody)
+    }
+
+    func testErrorPropagation_deserializer() async throws {
+        do {
+            let server = UniversalServer(handler: MockHandler())
+            _ = try await server.handle(
+                request: .init(soar_path: "/", method: .post),
+                requestBody: MockHandler.requestBody,
+                metadata: .init(),
+                forOperation: "op",
+                using: { MockHandler.greet($0) },
+                deserializer: { request, body, metadata in
+                    throw TestError()
+                },
+                serializer: { output, _ in
+                    fatalError()
+                }
+            )
+        } catch {
+            let serverError = try XCTUnwrap(error as? ServerError)
+            XCTAssertEqual(serverError.operationID, "op")
+            XCTAssertEqual(serverError.causeDescription, "Unknown")
+            XCTAssertEqual(serverError.underlyingError as? TestError, TestError())
+            XCTAssertEqual(serverError.request, .init(soar_path: "/", method: .post))
+            XCTAssertEqual(serverError.requestBody, MockHandler.requestBody)
+            XCTAssertEqual(serverError.requestMetadata, .init())
+            XCTAssertNil(serverError.operationInput)
+            XCTAssertNil(serverError.operationOutput)
+        }
+    }
+
+    func testErrorPropagation_transport() async throws {
+        do {
+            let server = UniversalServer(handler: MockHandler(shouldFail: true))
+            _ = try await server.handle(
+                request: .init(soar_path: "/", method: .post),
+                requestBody: MockHandler.requestBody,
+                metadata: .init(),
+                forOperation: "op",
+                using: { MockHandler.greet($0) },
+                deserializer: { request, body, metadata in
+                    let body = try XCTUnwrap(body)
+                    return try await String(collecting: body, upTo: 10)
+                },
+                serializer: { output, _ in
+                    fatalError()
+                }
+            )
+        } catch {
+            let serverError = try XCTUnwrap(error as? ServerError)
+            XCTAssertEqual(serverError.operationID, "op")
+            XCTAssertEqual(serverError.causeDescription, "User handler threw an error.")
+            XCTAssertEqual(serverError.underlyingError as? TestError, TestError())
+            XCTAssertEqual(serverError.request, .init(soar_path: "/", method: .post))
+            XCTAssertEqual(serverError.requestBody, MockHandler.requestBody)
+            XCTAssertEqual(serverError.requestMetadata, .init())
+            XCTAssertEqual(serverError.operationInput as? String, "hello")
+            XCTAssertNil(serverError.operationOutput)
+        }
+    }
+
+    func testErrorPropagation_serializer() async throws {
+        do {
+            let server = UniversalServer(handler: MockHandler())
+            _ = try await server.handle(
+                request: .init(soar_path: "/", method: .post),
+                requestBody: MockHandler.requestBody,
+                metadata: .init(),
+                forOperation: "op",
+                using: { MockHandler.greet($0) },
+                deserializer: { request, body, metadata in
+                    let body = try XCTUnwrap(body)
+                    return try await String(collecting: body, upTo: 10)
+                },
+                serializer: { output, _ in
+                    throw TestError()
+                }
+            )
+        } catch {
+            let serverError = try XCTUnwrap(error as? ServerError)
+            XCTAssertEqual(serverError.operationID, "op")
+            XCTAssertEqual(serverError.causeDescription, "Unknown")
+            XCTAssertEqual(serverError.underlyingError as? TestError, TestError())
+            XCTAssertEqual(serverError.request, .init(soar_path: "/", method: .post))
+            XCTAssertEqual(serverError.requestBody, MockHandler.requestBody)
+            XCTAssertEqual(serverError.requestMetadata, .init())
+            XCTAssertEqual(serverError.operationInput as? String, "hello")
+            XCTAssertEqual(serverError.operationOutput as? String, "bye")
+        }
+    }
 
     func testApiPathComponentsWithServerPrefix_noPrefix() throws {
         let server = UniversalServer(

--- a/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
+++ b/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
@@ -155,6 +155,8 @@ class Test_Runtime: XCTestCase {
     }
 }
 
+struct TestError: Error, Equatable {}
+
 /// Asserts that a given URL's absolute string representation is equal to an expected string.
 ///
 /// - Parameters:

--- a/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
+++ b/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
@@ -157,6 +157,49 @@ class Test_Runtime: XCTestCase {
 
 struct TestError: Error, Equatable {}
 
+struct MockMiddleware: ClientMiddleware, ServerMiddleware {
+    enum FailurePhase {
+        case never
+        case onRequest
+        case onResponse
+    }
+    var failurePhase: FailurePhase = .never
+    
+    func intercept(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        baseURL: URL,
+        operationID: String,
+        next: (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        if failurePhase == .onRequest {
+            throw TestError()
+        }
+        let (response, responseBody) = try await next(request, body, baseURL)
+        if failurePhase == .onResponse {
+            throw TestError()
+        }
+        return (response, responseBody)
+    }
+    
+    func intercept(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        metadata: ServerRequestMetadata,
+        operationID: String,
+        next: (HTTPRequest, HTTPBody?, ServerRequestMetadata) async throws -> (HTTPResponse, HTTPBody?)
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        if failurePhase == .onRequest {
+            throw TestError()
+        }
+        let (response, responseBody) = try await next(request, body, metadata)
+        if failurePhase == .onResponse {
+            throw TestError()
+        }
+        return (response, responseBody)
+    }
+}
+
 /// Asserts that a given URL's absolute string representation is equal to an expected string.
 ///
 /// - Parameters:

--- a/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
+++ b/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
@@ -164,7 +164,7 @@ struct MockMiddleware: ClientMiddleware, ServerMiddleware {
         case onResponse
     }
     var failurePhase: FailurePhase = .never
-    
+
     func intercept(
         _ request: HTTPRequest,
         body: HTTPBody?,
@@ -181,7 +181,7 @@ struct MockMiddleware: ClientMiddleware, ServerMiddleware {
         }
         return (response, responseBody)
     }
-    
+
     func intercept(
         _ request: HTTPRequest,
         body: HTTPBody?,


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apple/swift-openapi-generator/issues/302 and https://github.com/apple/swift-openapi-generator/issues/17.

The issue was that we hid away errors thrown in transports and middlewares, and the adopter would get `ClientError` where the `underlyingError` wasn't the error thrown by the underlying transport/middleware, but instead a private wrapper of ours.

### Modifications

Make sure `{Client,Server}Error.underlyingError` contains the error thrown from the underlying transport/middleware when that was the cause of the error, otherwise keep `RuntimeError` there as was the behavior until now.

Also added a `causeDescription` property on both public error types to allow communicating the context for the underlying error.

Also made sure middleware errors are now wrapped in Client/ServerError, they weren't before so didn't contain the context necessary to debug issues well.

### Result

Adopters can now extract the errors thrown e.g. by URLSession from our public error types using the `underlyingError` property and understand the context of where it was thrown by checking the user-facing `causeDescription`.

Also, adopters now get enriched errors thrown from middlewares.

### Test Plan

Wrote unit tests for both UniversalClient and UniversalServer, inevitably found some minor bugs there as well, fixed them all, plus the unit tests now verify the behavior new in this PR.
