### PR TITLE
[Runtime] Improved content type matching

### DIFF
--- a/Sources/OpenAPIRuntime/Base/OpenAPIMIMEType.swift
+++ b/Sources/OpenAPIRuntime/Base/OpenAPIMIMEType.swift
@@ -279,7 +279,7 @@ extension OpenAPIMIMEType {
 
             // According to RFC 2045: https://www.rfc-editor.org/rfc/rfc2045#section-5.1
             // "Type, subtype, and parameter names are case-insensitive."
-            // Inferred: Parameter values are be case-sensitive.
+            // Inferred: Parameter values are case-sensitive.
 
             let receivedNormalizedParameters = Dictionary(
                 uniqueKeysWithValues: receivedParameters.map { ($0.key.lowercased(), $0.value) }

--- a/Sources/OpenAPIRuntime/Base/OpenAPIMIMEType.swift
+++ b/Sources/OpenAPIRuntime/Base/OpenAPIMIMEType.swift
@@ -187,3 +187,115 @@ extension OpenAPIMIMEType: LosslessStringConvertible {
             .joined(separator: "; ")
     }
 }
+
+// MARK: - Internals
+
+extension OpenAPIMIMEType {
+
+    /// The result of a match evaluation between two MIME types.
+    enum Match: Hashable {
+
+        /// The reason why two types are incompatible.
+        enum IncompatibilityReason: Hashable {
+
+            /// The types don't match.
+            case type
+
+            /// The subtypes don't match.
+            case subtype
+
+            /// The parameter of the provided name is missing or doesn't match.
+            case parameter(name: String)
+        }
+
+        /// The types are incompatible for the provided reason.
+        case incompatible(IncompatibilityReason)
+
+        /// The types match based on a full wildcard `*/*`.
+        case wildcard
+
+        /// The types match based on a subtype wildcard, such as `image/*`.
+        case subtypeWildcard
+
+        /// The types match across the type, subtype, and the provided number
+        /// of parameters.
+        case typeAndSubtype(matchedParameterCount: Int)
+
+        /// A numeric representation of the quality of the match, the higher
+        /// the closer the types are.
+        var score: Int {
+            switch self {
+            case .incompatible:
+                return 0
+            case .wildcard:
+                return 1
+            case .subtypeWildcard:
+                return 2
+            case .typeAndSubtype(let matchedParameterCount):
+                return 3 + matchedParameterCount
+            }
+        }
+    }
+
+    /// Computes whether two MIME types match.
+    /// - Parameters:
+    ///   - receivedType: The type component of the received MIME type.
+    ///   - receivedSubtype: The subtype component of the received MIME type.
+    ///   - receivedParameters: The parameters of the received MIME type.
+    ///   - option: The MIME type to match against.
+    /// - Returns: The match result.
+    static func evaluate(
+        receivedType: String,
+        receivedSubtype: String,
+        receivedParameters: [String: String],
+        against option: OpenAPIMIMEType
+    ) -> Match {
+        switch option.kind {
+        case .any:
+            return .wildcard
+        case .anySubtype(let expectedType):
+            guard receivedType.lowercased() == expectedType.lowercased() else {
+                return .incompatible(.type)
+            }
+            return .subtypeWildcard
+        case .concrete(let expectedType, let expectedSubtype):
+            guard
+                receivedType.lowercased() == expectedType.lowercased()
+                    && receivedSubtype.lowercased() == expectedSubtype.lowercased()
+            else {
+                return .incompatible(.subtype)
+            }
+
+            // A full concrete match, so also check parameters.
+            // The rule is:
+            //   1. If a received parameter is not found in the option,
+            //      that's okay and gets ignored.
+            //   2. If an option parameter is not received, this is an
+            //      incompatible content type match.
+            // This means we can just iterate over option parameters and
+            // check them against the received parameters, but we can
+            // ignore any received parameters that didn't appear in the
+            // option parameters.
+
+            // According to RFC 2045: https://www.rfc-editor.org/rfc/rfc2045#section-5.1
+            // "Type, subtype, and parameter names are case-insensitive."
+            // Inferred: Parameter values are be case-sensitive.
+
+            let receivedNormalizedParameters = Dictionary(
+                uniqueKeysWithValues: receivedParameters.map { ($0.key.lowercased(), $0.value) }
+            )
+            var matchedParameterCount = 0
+            for optionParameter in option.parameters {
+                let normalizedParameterName = optionParameter.key.lowercased()
+                guard
+                    let receivedValue = receivedNormalizedParameters[normalizedParameterName],
+                    receivedValue == optionParameter.value
+                else {
+                    return .incompatible(.parameter(name: normalizedParameterName))
+                }
+                matchedParameterCount += 1
+            }
+            return .typeAndSubtype(matchedParameterCount: matchedParameterCount)
+        }
+    }
+}

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Common.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Common.swift
@@ -66,10 +66,9 @@ extension Converter {
             )
             return (contentType: stringOption, match: match)
         }
-        let sortedOptions = evaluatedOptions.sorted { a, b in
-            a.match.score > b.match.score
-        }
-        let bestOption = sortedOptions[0]
+        let bestOption = evaluatedOptions.max { a, b in
+            a.match.score < b.match.score
+        }!  // Safe, we only get here if the array is not empty.
         let bestContentType = bestOption.contentType
         if case .incompatible = bestOption.match {
             throw RuntimeError.unexpectedContentTypeHeader(bestContentType)

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Common.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Common.swift
@@ -29,45 +29,52 @@ extension Converter {
         return OpenAPIMIMEType(rawValue)
     }
 
-    /// Checks whether a concrete content type matches an expected content type.
-    ///
-    /// The concrete content type can contain parameters, such as `charset`, but
-    /// they are ignored in the equality comparison.
-    ///
-    /// The expected content type can contain wildcards, such as */* and text/*.
+    /// Chooses the most appropriate content type for the provided received
+    /// content type and a list of options.
     /// - Parameters:
-    ///   - received: The concrete content type to validate against the other.
-    ///   - expectedRaw: The expected content type, can contain wildcards.
-    /// - Throws: A `RuntimeError` when `expectedRaw` is not a valid content type.
-    /// - Returns: A Boolean value representing whether the concrete content
-    /// type matches the expected one.
-    public func isMatchingContentType(received: OpenAPIMIMEType?, expectedRaw: String) throws -> Bool {
-        guard let received else {
-            return false
+    ///   - received: The received content type.
+    ///   - options: The options to match against.
+    /// - Returns: The most appropriate option.
+    /// - Throws: If none of the options match the received content type.
+    /// - Precondition: `options` must not be empty.
+    public func bestContentType(
+        received: OpenAPIMIMEType?,
+        options: [String]
+    ) throws -> String {
+        precondition(!options.isEmpty, "bestContentType options must not be empty.")
+        guard
+            let received,
+            case let .concrete(type: receivedType, subtype: receivedSubtype) = received.kind
+        else {
+            // If none received or if we received a wildcard, use the first one.
+            // This behavior isn't well defined by the OpenAPI specification.
+            // Note: We treat a partial wildcard, like `image/*` as a full
+            // wildcard `*/*`, but that's okay because for a concrete received
+            // content type the behavior of a wildcard is not clearly defined
+            // either.
+            return options[0]
         }
-        guard case let .concrete(type: receivedType, subtype: receivedSubtype) = received.kind else {
-            return false
+        let evaluatedOptions = try options.map { stringOption in
+            guard let parsedOption = OpenAPIMIMEType(stringOption) else {
+                throw RuntimeError.invalidExpectedContentType(stringOption)
+            }
+            let match = OpenAPIMIMEType.evaluate(
+                receivedType: receivedType,
+                receivedSubtype: receivedSubtype,
+                receivedParameters: received.parameters,
+                against: parsedOption
+            )
+            return (contentType: stringOption, match: match)
         }
-        guard let expectedContentType = OpenAPIMIMEType(expectedRaw) else {
-            throw RuntimeError.invalidExpectedContentType(expectedRaw)
+        let sortedOptions = evaluatedOptions.sorted { a, b in
+            a.match.score > b.match.score
         }
-        switch expectedContentType.kind {
-        case .any:
-            return true
-        case .anySubtype(let expectedType):
-            return receivedType.lowercased() == expectedType.lowercased()
-        case .concrete(let expectedType, let expectedSubtype):
-            return receivedType.lowercased() == expectedType.lowercased()
-                && receivedSubtype.lowercased() == expectedSubtype.lowercased()
+        let bestOption = sortedOptions[0]
+        let bestContentType = bestOption.contentType
+        if case .incompatible = bestOption.match {
+            throw RuntimeError.unexpectedContentTypeHeader(bestContentType)
         }
-    }
-
-    /// Returns an error to be thrown when an unexpected content type is
-    /// received.
-    /// - Parameter contentType: The content type that was received.
-    /// - Returns: An error representing an unexpected content type.
-    public func makeUnexpectedContentTypeError(contentType: OpenAPIMIMEType?) -> any Error {
-        RuntimeError.unexpectedContentTypeHeader(contentType?.description ?? "")
+        return bestContentType
     }
 
     // MARK: - Converter helper methods

--- a/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
+++ b/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
@@ -98,3 +98,48 @@ extension ServerError {
         )
     }
 }
+
+extension Converter {
+    /// Returns an error to be thrown when an unexpected content type is
+    /// received.
+    /// - Parameter contentType: The content type that was received.
+    /// - Returns: An error representing an unexpected content type.
+    @available(*, deprecated)
+    public func makeUnexpectedContentTypeError(contentType: OpenAPIMIMEType?) -> any Error {
+        RuntimeError.unexpectedContentTypeHeader(contentType?.description ?? "")
+    }
+
+    /// Checks whether a concrete content type matches an expected content type.
+    ///
+    /// The concrete content type can contain parameters, such as `charset`, but
+    /// they are ignored in the equality comparison.
+    ///
+    /// The expected content type can contain wildcards, such as */* and text/*.
+    /// - Parameters:
+    ///   - received: The concrete content type to validate against the other.
+    ///   - expectedRaw: The expected content type, can contain wildcards.
+    /// - Throws: A `RuntimeError` when `expectedRaw` is not a valid content type.
+    /// - Returns: A Boolean value representing whether the concrete content
+    /// type matches the expected one.
+    @available(*, deprecated)
+    public func isMatchingContentType(received: OpenAPIMIMEType?, expectedRaw: String) throws -> Bool {
+        guard let received else {
+            return false
+        }
+        guard case let .concrete(type: receivedType, subtype: receivedSubtype) = received.kind else {
+            return false
+        }
+        guard let expectedContentType = OpenAPIMIMEType(expectedRaw) else {
+            throw RuntimeError.invalidExpectedContentType(expectedRaw)
+        }
+        switch expectedContentType.kind {
+        case .any:
+            return true
+        case .anySubtype(let expectedType):
+            return receivedType.lowercased() == expectedType.lowercased()
+        case .concrete(let expectedType, let expectedSubtype):
+            return receivedType.lowercased() == expectedType.lowercased()
+                && receivedSubtype.lowercased() == expectedSubtype.lowercased()
+        }
+    }
+}

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
@@ -100,7 +100,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
                 options: [
                     "whoops"
                 ],
-                expected: "application/json"
+                expected: "-"
             )
         )
         XCTAssertThrowsError(
@@ -110,7 +110,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
                     "text/plain",
                     "image/*",
                 ],
-                expected: "application/json"
+                expected: "-"
             )
         )
         try testCase(

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
@@ -25,6 +25,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
 
     // MARK: Miscs
 
+    @available(*, deprecated)
     func testContentTypeMatching() throws {
         let cases: [(received: String, expected: String, isMatch: Bool)] = [
             ("application/json", "application/json", true),
@@ -52,6 +53,153 @@ final class Test_CommonConverterExtensions: Test_Runtime {
                 "Wrong result for (\(testCase.received), \(testCase.expected), \(testCase.isMatch))"
             )
         }
+    }
+
+    func testBestContentType() throws {
+        func testCase(
+            received: String?,
+            options: [String],
+            expected expectedChoice: String,
+            file: StaticString = #file,
+            line: UInt = #line
+        ) throws {
+            let choice = try converter.bestContentType(
+                received: received.map { .init($0)! },
+                options: options
+            )
+            XCTAssertEqual(choice, expectedChoice, file: file, line: line)
+        }
+
+        try testCase(
+            received: nil,
+            options: [
+                "application/json",
+                "*/*",
+            ],
+            expected: "application/json"
+        )
+        try testCase(
+            received: "*/*",
+            options: [
+                "application/json",
+                "*/*",
+            ],
+            expected: "application/json"
+        )
+        try testCase(
+            received: "application/*",
+            options: [
+                "application/json",
+                "*/*",
+            ],
+            expected: "application/json"
+        )
+        XCTAssertThrowsError(
+            try testCase(
+                received: "application/json",
+                options: [
+                    "whoops"
+                ],
+                expected: "application/json"
+            )
+        )
+        XCTAssertThrowsError(
+            try testCase(
+                received: "application/json",
+                options: [
+                    "text/plain",
+                    "image/*",
+                ],
+                expected: "application/json"
+            )
+        )
+        try testCase(
+            received: "application/json; charset=utf-8; version=1",
+            options: [
+                "*/*",
+                "application/*",
+                "application/json",
+                "application/json; charset=utf-8",
+                "application/json; charset=utf-8; version=1",
+            ],
+            expected: "application/json; charset=utf-8; version=1"
+        )
+        try testCase(
+            received: "application/json; version=1; CHARSET=utf-8",
+            options: [
+                "*/*",
+                "application/*",
+                "application/json",
+                "application/json; charset=utf-8",
+                "application/json; charset=utf-8; version=1",
+            ],
+            expected: "application/json; charset=utf-8; version=1"
+        )
+        try testCase(
+            received: "application/json",
+            options: [
+                "application/json; charset=utf-8",
+                "application/json; charset=utf-8; version=1",
+                "*/*",
+                "application/*",
+                "application/json",
+            ],
+            expected: "application/json"
+        )
+        try testCase(
+            received: "application/json; charset=utf-8",
+            options: [
+                "application/json; charset=utf-8; version=1",
+                "*/*",
+                "application/*",
+                "application/json",
+            ],
+            expected: "application/json"
+        )
+        try testCase(
+            received: "application/json; charset=utf-8; version=1",
+            options: [
+                "*/*",
+                "application/*",
+                "application/json; charset=utf-8",
+                "application/json",
+            ],
+            expected: "application/json; charset=utf-8"
+        )
+        try testCase(
+            received: "application/json; charset=utf-8; version=1",
+            options: [
+                "*/*",
+                "application/*",
+            ],
+            expected: "application/*"
+        )
+        try testCase(
+            received: "application/json; charset=utf-8; version=1",
+            options: [
+                "*/*"
+            ],
+            expected: "*/*"
+        )
+
+        try testCase(
+            received: "image/png",
+            options: [
+                "image/*",
+                "*/*",
+            ],
+            expected: "image/*"
+        )
+        XCTAssertThrowsError(
+            try testCase(
+                received: "text/csv",
+                options: [
+                    "text/html",
+                    "application/json",
+                ],
+                expected: "-"
+            )
+        )
     }
 
     // MARK: Converter helper methods


### PR DESCRIPTION
### Motivation

The runtime changes for https://github.com/apple/swift-openapi-generator/issues/315.

### Modifications

- Introduces a new SPI method `Converter.bestContentType` that takes a received content type value and from a provided list of other content types, picks the most appropriate one. This actually follows the specification now, by going from most specific (including parameter matching) to least specific (most wildcard-y).
- Deprecates the previously used methods `Converter.makeUnexpectedContentTypeError` and `Converter.isMatchingContentType`.

### Result

SPI methods that the generated code can use to correctly match content types.

### Test Plan

Added unit tests.
