### PR TITLE
Disable warnings-as-errors for nightlies

### DIFF
--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -11,7 +11,8 @@ services:
   test:
     image: *image
     environment:
-      - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
+      # Disable warnings as errors on nightlies as they are still in-development.
+      # - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
 


### PR DESCRIPTION
### Motivation

Same as https://github.com/apple/swift-openapi-generator/pull/353 but for the runtime package.

### Modifications

Disable warnings as errors on CI for nightlies.

### Result

_[After your change, what will change.]_

### Test Plan

CI should pass again.
