### PR TITLE
Base64EncodedData initializer taking an array slice shouldn't have a label

### DIFF
--- a/Sources/OpenAPIRuntime/Base/Base64EncodedData.swift
+++ b/Sources/OpenAPIRuntime/Base/Base64EncodedData.swift
@@ -56,7 +56,13 @@ public struct Base64EncodedData: Sendable, Hashable {
 
     /// Initializes an instance of ``Base64EncodedData`` wrapping the provided slice of bytes.
     /// - Parameter data: The underlying bytes to wrap.
+    @available(*, deprecated, renamed: "init", message: "Use the init(_ data: ArraySlice<UInt8>) instead.")
+
     public init(data: ArraySlice<UInt8>) { self.data = data }
+
+    /// Initializes an instance of ``Base64EncodedData`` wrapping the provided slice of bytes.
+    /// - Parameter data: The underlying bytes to wrap.
+    public init(_ data: ArraySlice<UInt8>) { self.data = data }
 }
 
 extension Base64EncodedData: Codable {
@@ -74,7 +80,7 @@ extension Base64EncodedData: Codable {
         guard let data = Data(base64Encoded: base64EncodedString, options: options) else {
             throw RuntimeError.invalidBase64String(base64EncodedString)
         }
-        self.init(data: ArraySlice(data))
+        self.init(ArraySlice(data))
     }
 
     /// Encodes the binary data as a base64-encoded string.

--- a/Sources/OpenAPIRuntime/Base/Base64EncodedData.swift
+++ b/Sources/OpenAPIRuntime/Base/Base64EncodedData.swift
@@ -56,13 +56,23 @@ public struct Base64EncodedData: Sendable, Hashable {
 
     /// Initializes an instance of ``Base64EncodedData`` wrapping the provided slice of bytes.
     /// - Parameter data: The underlying bytes to wrap.
-    @available(*, deprecated, renamed: "init", message: "Use the init(_ data: ArraySlice<UInt8>) instead.")
+    @available(*, deprecated, renamed: "init(_:)")
 
     public init(data: ArraySlice<UInt8>) { self.data = data }
 
     /// Initializes an instance of ``Base64EncodedData`` wrapping the provided slice of bytes.
     /// - Parameter data: The underlying bytes to wrap.
     public init(_ data: ArraySlice<UInt8>) { self.data = data }
+
+    /// Initializes an instance of ``Base64EncodedData`` wrapping the provided sequence of bytes.
+    /// - Parameter data: The underlying bytes to wrap.
+    public init(_ data: some Sequence<UInt8>) { self.init(ArraySlice(data)) }
+}
+
+extension Base64EncodedData: ExpressibleByArrayLiteral {
+    /// Initializes an instance of ``Base64EncodedData`` with a sequence of bytes provided as an array literal.
+    /// - Parameter elements: The sequence of `UInt8` elements representing the underlying bytes.
+    public init(arrayLiteral elements: UInt8...) { self.init(elements) }
 }
 
 extension Base64EncodedData: Codable {
@@ -80,7 +90,7 @@ extension Base64EncodedData: Codable {
         guard let data = Data(base64Encoded: base64EncodedString, options: options) else {
             throw RuntimeError.invalidBase64String(base64EncodedString)
         }
-        self.init(ArraySlice(data))
+        self.init(data)
     }
 
     /// Encodes the binary data as a base64-encoded string.

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -241,14 +241,14 @@ final class Test_OpenAPIValue: Test_Runtime {
     }
 
     func testEncoding_base64_success() throws {
-        let encodedData = Base64EncodedData(ArraySlice(testStructData))
+        let encodedData = Base64EncodedData(testStructData)
 
         let JSONEncoded = try JSONEncoder().encode(encodedData)
         XCTAssertEqual(String(data: JSONEncoded, encoding: .utf8)!, testStructBase64EncodedString)
     }
 
     func testDecoding_base64_success() throws {
-        let encodedData = Base64EncodedData(ArraySlice(testStructData))
+        let encodedData = Base64EncodedData(testStructData)
 
         // `testStructBase64EncodedString` quoted and base64-encoded again
         let JSONEncoded = Data(base64Encoded: "ImV5SnVZVzFsSWpvaVJteDFabVo2SW4wPSI=")!
@@ -257,7 +257,7 @@ final class Test_OpenAPIValue: Test_Runtime {
     }
 
     func testEncodingDecodingRoundtrip_base64_success() throws {
-        let encodedData = Base64EncodedData(ArraySlice(testStructData))
+        let encodedData = Base64EncodedData(testStructData)
         XCTAssertEqual(
             try JSONDecoder().decode(Base64EncodedData.self, from: JSONEncoder().encode(encodedData)),
             encodedData

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -241,14 +241,14 @@ final class Test_OpenAPIValue: Test_Runtime {
     }
 
     func testEncoding_base64_success() throws {
-        let encodedData = Base64EncodedData(data: ArraySlice(testStructData))
+        let encodedData = Base64EncodedData(ArraySlice(testStructData))
 
         let JSONEncoded = try JSONEncoder().encode(encodedData)
         XCTAssertEqual(String(data: JSONEncoded, encoding: .utf8)!, testStructBase64EncodedString)
     }
 
     func testDecoding_base64_success() throws {
-        let encodedData = Base64EncodedData(data: ArraySlice(testStructData))
+        let encodedData = Base64EncodedData(ArraySlice(testStructData))
 
         // `testStructBase64EncodedString` quoted and base64-encoded again
         let JSONEncoded = Data(base64Encoded: "ImV5SnVZVzFsSWpvaVJteDFabVo2SW4wPSI=")!
@@ -257,7 +257,7 @@ final class Test_OpenAPIValue: Test_Runtime {
     }
 
     func testEncodingDecodingRoundtrip_base64_success() throws {
-        let encodedData = Base64EncodedData(data: ArraySlice(testStructData))
+        let encodedData = Base64EncodedData(ArraySlice(testStructData))
         XCTAssertEqual(
             try JSONDecoder().decode(Base64EncodedData.self, from: JSONEncoder().encode(encodedData)),
             encodedData


### PR DESCRIPTION
### Motivation

 - Fixes [#369](https://github.com/apple/swift-openapi-generator/issues/368)

### Modifications

- Remove init label argument from Base64EncodedData

### Result

- The Base64EncodedData init will be called without the label.

### Test Plan

- Adjust some tests from Test_OpenAPIValue
