### PR TITLE
Change type of HTTPBody.Length.known from Int to Int64

### DIFF
--- a/Sources/OpenAPIRuntime/Interface/HTTPBody.swift
+++ b/Sources/OpenAPIRuntime/Interface/HTTPBody.swift
@@ -125,17 +125,17 @@ public final class HTTPBody: @unchecked Sendable {
     /// the input sequence can be iterated.
     public let iterationBehavior: OpenAPIRuntime.IterationBehavior
 
-    /// Describes the total length of the body, if known.
+    /// Describes the total length of the body, in bytes, if known.
     public enum Length: Sendable, Equatable {
 
         /// Total length not known yet.
         case unknown
 
         /// Total length is known.
-        case known(Int)
+        case known(Int64)
     }
 
-    /// The total length of the body, if known.
+    /// The total length of the body, in bytes, if known.
     public let length: Length
 
     /// The underlying type-erased async sequence.
@@ -257,7 +257,7 @@ extension HTTPBody {
     /// Creates a new body with the provided byte chunk.
     /// - Parameter bytes: A byte chunk.
     @inlinable public convenience init(_ bytes: ByteChunk) {
-        self.init([bytes], length: .known(bytes.count), iterationBehavior: .multiple)
+        self.init([bytes], length: .known(Int64(bytes.count)), iterationBehavior: .multiple)
     }
 
     /// Creates a new body with the provided byte sequence.
@@ -283,7 +283,7 @@ extension HTTPBody {
     /// Creates a new body with the provided byte collection.
     /// - Parameter bytes: A byte chunk.
     @inlinable public convenience init(_ bytes: some Collection<UInt8> & Sendable) {
-        self.init(bytes, length: .known(bytes.count))
+        self.init(bytes, length: .known(Int64(bytes.count)))
     }
 
     /// Creates a new body with the provided async throwing stream.

--- a/Sources/OpenAPIRuntime/Multipart/MultipartFramesToRawPartsSequence.swift
+++ b/Sources/OpenAPIRuntime/Multipart/MultipartFramesToRawPartsSequence.swift
@@ -77,7 +77,7 @@ extension HTTPBody {
         let stream = AsyncThrowingStream(unfolding: bodyClosure)
         let length: HTTPBody.Length
         if let contentLengthString = headerFields[.contentLength], let contentLength = Int(contentLengthString) {
-            length = .known(contentLength)
+            length = .known(Int64(contentLength))
         } else {
             length = .unknown
         }


### PR DESCRIPTION
### Motivation

The associated value of  enum case `HTTPBody.Length.known` was `Int`, and, on watchOS, `Int = Int32`, which is not ideal for a content length.

### Modifications

- (API breaking) Change type of HTTPBody.Length.known from Int to Int64.

### Result

Can now express larger values for content type on 32-bit platforms.

### Test Plan

Unit tests pass.

### Related Issues

- Fixes https://github.com/apple/swift-openapi-generator/issues/354.

### Note

I have marked this PR as `semver/major` as it constitutes the first of the PRs we make in the run up to 1.0.0-alpha.1 and the release notes generator should therefore catch us from inadvertently cutting another pre-1.0 patch release.