### PR TITLE
Remove no-longer-needed `@preconcurrency`s

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/Converter.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter.swift
@@ -15,7 +15,7 @@
 import Foundation
 #else
 @preconcurrency import class Foundation.JSONEncoder
-@preconcurrency import class Foundation.JSONDecoder
+import class Foundation.JSONDecoder
 #endif
 
 /// Converter between generated and HTTP currency types.

--- a/Sources/OpenAPIRuntime/Errors/ClientError.swift
+++ b/Sources/OpenAPIRuntime/Errors/ClientError.swift
@@ -13,12 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import HTTPTypes
-#if canImport(Darwin)
-import Foundation
-#else
-@preconcurrency import struct Foundation.URL
-@preconcurrency import protocol Foundation.LocalizedError
-#endif
+import struct Foundation.URL
+import protocol Foundation.LocalizedError
 
 /// An error thrown by a client performing an OpenAPI operation.
 ///

--- a/Sources/OpenAPIRuntime/Interface/ClientTransport.swift
+++ b/Sources/OpenAPIRuntime/Interface/ClientTransport.swift
@@ -13,11 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import HTTPTypes
-#if canImport(Darwin)
 import struct Foundation.URL
-#else
-@preconcurrency import struct Foundation.URL
-#endif
 
 /// A type that performs HTTP operations.
 ///

--- a/Sources/OpenAPIRuntime/Interface/UniversalServer.swift
+++ b/Sources/OpenAPIRuntime/Interface/UniversalServer.swift
@@ -16,11 +16,11 @@ import HTTPTypes
 
 #if canImport(Darwin)
 import struct Foundation.URL
-import struct Foundation.URLComponents
 #else
 @preconcurrency import struct Foundation.URL
-@preconcurrency import struct Foundation.URLComponents
 #endif
+import struct Foundation.URLComponents
+
 
 /// OpenAPI document-agnostic HTTP server used by OpenAPI document-specific,
 /// generated servers to perform request deserialization, middleware and handler

--- a/Tests/OpenAPIRuntimeTests/URICoder/Test_URICodingRoundtrip.swift
+++ b/Tests/OpenAPIRuntimeTests/URICoder/Test_URICodingRoundtrip.swift
@@ -13,9 +13,6 @@
 //===----------------------------------------------------------------------===//
 import XCTest
 @_spi(Generated) @testable import OpenAPIRuntime
-#if os(Linux)
-@preconcurrency import Foundation
-#endif
 
 final class Test_URICodingRoundtrip: Test_Runtime {
 


### PR DESCRIPTION
See https://github.com/apple/swift-openapi-generator/pull/396.