### PR TITLE
Add visionOS platform support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let swiftSettings: [SwiftSetting] = [
 let package = Package(
     name: "swift-openapi-runtime",
     platforms: [
-        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6),
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .visionOS(.v1)
     ],
     products: [
         .library(


### PR DESCRIPTION
### Motivation

While this isn't technically necessary, as all versions of a platform not explicitly mentioned are assumed to be supported, it's better to be explicit here.

### Modifications

Add `visionOS(.v1)` to the list of supported platforms.

### Result

Clearer support matrix.

### Test Plan

N/A, this is basically just a documentation change.
