### PR TITLE
[Runtime] Add headerFields and body to UndocumentedPayload

### DIFF
--- a/Sources/OpenAPIRuntime/Base/UndocumentedPayload.swift
+++ b/Sources/OpenAPIRuntime/Base/UndocumentedPayload.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import HTTPTypes
+
 /// A payload value used by undocumented operation responses.
 ///
 /// Each operation's `Output` enum type needs to exhaustively
@@ -20,6 +22,19 @@
 /// `undocumented` enum case is used when such a status code is
 /// detected.
 public struct UndocumentedPayload: Sendable, Hashable {
-    /// Creates a new payload.
-    public init() {}
+
+    /// The header fields contained in the response.
+    public var headerFields: HTTPFields
+
+    /// The body stream of this part, if present.
+    public var body: HTTPBody?
+
+    /// Creates a new part.
+    /// - Parameters:
+    ///   - headerFields: The header fields contained in the response.
+    ///   - body: The body stream of this part, if present.
+    public init(headerFields: HTTPFields = [:], body: HTTPBody? = nil) {
+        self.headerFields = headerFields
+        self.body = body
+    }
 }

--- a/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
+++ b/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
@@ -15,3 +15,10 @@ import Foundation
 import HTTPTypes
 
 // MARK: - Functionality to be removed in the future
+
+extension UndocumentedPayload {
+    /// Creates a new payload.
+    @available(*, deprecated, renamed: "init(headerFields:body:)") @_disfavoredOverload public init() {
+        self.init(headerFields: [:], body: nil)
+    }
+}


### PR DESCRIPTION
### Motivation

The runtime changes for https://github.com/apple/swift-openapi-generator/issues/299.

### Modifications

Added `headerFields` and `body` properties to `UndocumentedPayload`, allowing adopters to access the full request information when an undocumented response is returned.

### Result

Easier access to the raw payload when an undocumented response is returned.

### Test Plan

These are just the runtime changes, tested together with generated changes.
