### PR TITLE
Mark RuntimeError as @_spi(Generated) too

### DIFF
--- a/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
+++ b/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
@@ -15,7 +15,7 @@ import protocol Foundation.LocalizedError
 import struct Foundation.Data
 
 /// Error thrown by generated code.
-internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, PrettyStringConvertible {
+@_spi(Generated) public enum RuntimeError: Error, CustomStringConvertible, LocalizedError, PrettyStringConvertible {
 
     // Miscs
     case invalidServerURL(String)


### PR DESCRIPTION
### Motivation

I'm writing a networking library that makes use of the heavy lifting provided by `UniversalClient`, and figured I'd use `RuntimeError` as well since they cover pretty much all of my use-cases. 

### Modifications

Marked `RuntimeError` as `@_spi(Generated) public` instead of `internal`

### Result

`RuntimeError` can be imported using `@_spi(Generated) import enum OpenAPIRuntime.RuntimeError`

### Test Plan

None
