### PR TITLE
Add a hook for intercepting decoding errors

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/Configuration.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Configuration.swift
@@ -96,6 +96,10 @@ extension JSONDecoder.DateDecodingStrategy {
     }
 }
 
+public protocol DecodingErrorHandler: Sendable {
+    func willThrow(_ error: any Error)
+}
+
 /// A set of configuration values used by the generated client and server types.
 public struct Configuration: Sendable {
 
@@ -105,6 +109,8 @@ public struct Configuration: Sendable {
     /// The generator to use when creating mutlipart bodies.
     public var multipartBoundaryGenerator: any MultipartBoundaryGenerator
 
+    public var decodingErrorHandler: (any DecodingErrorHandler)?
+
     /// Creates a new configuration with the specified values.
     ///
     /// - Parameters:
@@ -113,9 +119,11 @@ public struct Configuration: Sendable {
     ///   - multipartBoundaryGenerator: The generator to use when creating mutlipart bodies.
     public init(
         dateTranscoder: any DateTranscoder = .iso8601,
-        multipartBoundaryGenerator: any MultipartBoundaryGenerator = .random
+        multipartBoundaryGenerator: any MultipartBoundaryGenerator = .random,
+        decodingErrorHandler: (any DecodingErrorHandler)? = nil
     ) {
         self.dateTranscoder = dateTranscoder
         self.multipartBoundaryGenerator = multipartBoundaryGenerator
+        self.decodingErrorHandler = decodingErrorHandler
     }
 }

--- a/Sources/OpenAPIRuntime/Conversion/CurrencyExtensions.swift
+++ b/Sources/OpenAPIRuntime/Conversion/CurrencyExtensions.swift
@@ -132,7 +132,14 @@ extension Converter {
     /// - Throws: An error if decoding from the body fails.
     func convertJSONToBodyCodable<T: Decodable>(_ body: HTTPBody) async throws -> T {
         let data = try await Data(collecting: body, upTo: .max)
-        return try decoder.decode(T.self, from: data)
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            if let decodingErrorHandler = configuration.decodingErrorHandler {
+                decodingErrorHandler.willThrow(error)
+            }
+            throw error
+        }
     }
 
     /// Returns a JSON body for the provided encodable value.


### PR DESCRIPTION
### Motivation

It's useful for clients to be able to have a centralized way to handle decoding errors, which can be useful for logging or telemetry.

See https://github.com/apple/swift-openapi-generator/issues/522 for more discussion on this.

### Modifications

Add a new `DecodingErrorHandler` protocol which has a single `willThrow(_ error: any Error)` requirement.

A decoding handler can be passed to the client configuration on initialization.

This is just a proof-of-concept, if this direction is reasonable, it should be fleshed out to handle all decoding paths.

### Result

With this change, errors produced by body decoders can be intercepted in a centralized way for all methods going through the `Client`.

### Test Plan

I added a simple unit test. More tests would need to be added to sufficiently cover the functionality being introduced here.
