### PR TITLE
[Runtime] Add support of deepObject style in query params

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/CurrencyExtensions.swift
+++ b/Sources/OpenAPIRuntime/Conversion/CurrencyExtensions.swift
@@ -29,7 +29,9 @@ extension ParameterStyle {
     ) {
         let resolvedStyle = style ?? .defaultForQueryItems
         let resolvedExplode = explode ?? ParameterStyle.defaultExplodeFor(forStyle: resolvedStyle)
-        guard resolvedStyle == .form else {
+        switch resolvedStyle {
+        case .form, .deepObject: break
+        default:
             throw RuntimeError.unsupportedParameterStyle(
                 name: name,
                 location: .query,

--- a/Sources/OpenAPIRuntime/Conversion/ParameterStyles.swift
+++ b/Sources/OpenAPIRuntime/Conversion/ParameterStyles.swift
@@ -26,6 +26,11 @@
     ///
     /// Details: https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.2
     case simple
+    
+    /// The deepObject style.
+    ///
+    /// Details: https://spec.openapis.org/oas/v3.1.0.html#style-values
+    case deepObject
 }
 
 extension ParameterStyle {
@@ -53,6 +58,7 @@ extension URICoderConfiguration.Style {
         switch style {
         case .form: self = .form
         case .simple: self = .simple
+        case .deepObject: self = .deepObject
         }
     }
 }

--- a/Sources/OpenAPIRuntime/URICoder/Common/URICoderConfiguration.swift
+++ b/Sources/OpenAPIRuntime/URICoder/Common/URICoderConfiguration.swift
@@ -25,6 +25,9 @@ struct URICoderConfiguration {
 
         /// A style for form-based URI expansion.
         case form
+        
+        /// A style for nested variable expansion
+        case deepObject
     }
 
     /// A character used to escape the space character.

--- a/Sources/OpenAPIRuntime/URICoder/Serialization/URISerializer.swift
+++ b/Sources/OpenAPIRuntime/URICoder/Serialization/URISerializer.swift
@@ -69,6 +69,12 @@ extension URISerializer {
 
         /// Nested containers are not supported.
         case nestedContainersNotSupported
+        
+        /// Deep object arrays are not supported.
+        case deepObjectsArrayNotSupported
+        
+        /// An invalid configuration was detected.
+        case invalidConfiguration(String)
     }
 
     /// Computes an escaped version of the provided string.
@@ -117,6 +123,7 @@ extension URISerializer {
             switch configuration.style {
             case .form: keyAndValueSeparator = "="
             case .simple: keyAndValueSeparator = nil
+            case .deepObject: keyAndValueSeparator = "="
             }
             try serializePrimitiveKeyValuePair(primitive, forKey: key, separator: keyAndValueSeparator)
         case .array(let array): try serializeArray(array.map(unwrapPrimitiveValue), forKey: key)
@@ -180,6 +187,8 @@ extension URISerializer {
         case (.simple, _):
             keyAndValueSeparator = nil
             pairSeparator = ","
+        case (.deepObject, _):
+            throw SerializationError.deepObjectsArrayNotSupported
         }
         func serializeNext(_ element: URIEncodedNode.Primitive) throws {
             if let keyAndValueSeparator {
@@ -228,8 +237,18 @@ extension URISerializer {
         case (.simple, false):
             keyAndValueSeparator = ","
             pairSeparator = ","
+        case (.deepObject, true):
+            keyAndValueSeparator = "="
+            pairSeparator = "&"
+        case (.deepObject, false):
+            let reason = "Deep object style is only valid with explode set to true"
+            throw SerializationError.invalidConfiguration(reason)
         }
 
+        func serializeNestedKey(_ elementKey: String, forKey rootKey: String) -> String {
+            guard case .deepObject = configuration.style else { return elementKey }
+            return rootKey + "[" + elementKey + "]"
+        }
         func serializeNext(_ element: URIEncodedNode.Primitive, forKey elementKey: String) throws {
             try serializePrimitiveKeyValuePair(element, forKey: elementKey, separator: keyAndValueSeparator)
         }
@@ -238,10 +257,13 @@ extension URISerializer {
             data.append(containerKeyAndValue)
         }
         for (elementKey, element) in sortedDictionary.dropLast() {
-            try serializeNext(element, forKey: elementKey)
+            try serializeNext(element, forKey: serializeNestedKey(elementKey, forKey: key))
             data.append(pairSeparator)
         }
-        if let (elementKey, element) = sortedDictionary.last { try serializeNext(element, forKey: elementKey) }
+        
+        if let (elementKey, element) = sortedDictionary.last {
+            try serializeNext(element, forKey: serializeNestedKey(elementKey, forKey: key))
+        }
     }
 }
 

--- a/Tests/OpenAPIRuntimeTests/URICoder/Encoding/Test_URIEncoder.swift
+++ b/Tests/OpenAPIRuntimeTests/URICoder/Encoding/Test_URIEncoder.swift
@@ -23,4 +23,12 @@ final class Test_URIEncoder: Test_Runtime {
         let encodedString = try encoder.encode(Foo(bar: "hello world"), forKey: "root")
         XCTAssertEqual(encodedString, "bar=hello+world")
     }
+    
+    func testNestedEncoding() throws {
+        struct Foo: Encodable { var bar: String }
+        let serializer = URISerializer(configuration: .deepObjectExplode)
+        let encoder = URIEncoder(serializer: serializer)
+        let encodedString = try encoder.encode(Foo(bar: "hello world"), forKey: "root")
+        XCTAssertEqual(encodedString, "root%5Bbar%5D=hello%20world")
+    }
 }

--- a/Tests/OpenAPIRuntimeTests/URICoder/Parsing/Test_URIParser.swift
+++ b/Tests/OpenAPIRuntimeTests/URICoder/Parsing/Test_URIParser.swift
@@ -17,7 +17,7 @@ import XCTest
 final class Test_URIParser: Test_Runtime {
 
     let testedVariants: [URICoderConfiguration] = [
-        .formExplode, .formUnexplode, .simpleExplode, .simpleUnexplode, .formDataExplode, .formDataUnexplode,
+        .formExplode, .formUnexplode, .simpleExplode, .simpleUnexplode, .formDataExplode, .formDataUnexplode, .deepObjectExplode
     ]
 
     func testParsing() throws {
@@ -29,7 +29,8 @@ final class Test_URIParser: Test_Runtime {
                     simpleExplode: .custom("", value: ["": [""]]),
                     simpleUnexplode: .custom("", value: ["": [""]]),
                     formDataExplode: "empty=",
-                    formDataUnexplode: "empty="
+                    formDataUnexplode: "empty=",
+                    deepObjectExplode: "empty="
                 ),
                 value: ["empty": [""]]
             ),
@@ -40,7 +41,8 @@ final class Test_URIParser: Test_Runtime {
                     simpleExplode: .custom("", value: ["": [""]]),
                     simpleUnexplode: .custom("", value: ["": [""]]),
                     formDataExplode: "",
-                    formDataUnexplode: ""
+                    formDataUnexplode: "",
+                    deepObjectExplode: ""
                 ),
                 value: [:]
             ),
@@ -51,7 +53,8 @@ final class Test_URIParser: Test_Runtime {
                     simpleExplode: .custom("fred", value: ["": ["fred"]]),
                     simpleUnexplode: .custom("fred", value: ["": ["fred"]]),
                     formDataExplode: "who=fred",
-                    formDataUnexplode: "who=fred"
+                    formDataUnexplode: "who=fred",
+                    deepObjectExplode: "who=fred"
                 ),
                 value: ["who": ["fred"]]
             ),
@@ -62,7 +65,8 @@ final class Test_URIParser: Test_Runtime {
                     simpleExplode: .custom("Hello%20World", value: ["": ["Hello World"]]),
                     simpleUnexplode: .custom("Hello%20World", value: ["": ["Hello World"]]),
                     formDataExplode: "hello=Hello+World",
-                    formDataUnexplode: "hello=Hello+World"
+                    formDataUnexplode: "hello=Hello+World",
+                    deepObjectExplode: "hello=Hello%20World"
                 ),
                 value: ["hello": ["Hello World"]]
             ),
@@ -73,7 +77,8 @@ final class Test_URIParser: Test_Runtime {
                     simpleExplode: .custom("red,green,blue", value: ["": ["red", "green", "blue"]]),
                     simpleUnexplode: .custom("red,green,blue", value: ["": ["red", "green", "blue"]]),
                     formDataExplode: "list=red&list=green&list=blue",
-                    formDataUnexplode: "list=red,green,blue"
+                    formDataUnexplode: "list=red,green,blue",
+                    deepObjectExplode: "list=red&list=green&list=blue"
                 ),
                 value: ["list": ["red", "green", "blue"]]
             ),
@@ -93,7 +98,8 @@ final class Test_URIParser: Test_Runtime {
                     formDataUnexplode: .custom(
                         "keys=comma,%2C,dot,.,semi,%3B",
                         value: ["keys": ["comma", ",", "dot", ".", "semi", ";"]]
-                    )
+                    ), 
+                    deepObjectExplode: "comma=%2C&dot=.&semi=%3B"
                 ),
                 value: ["semi": [";"], "dot": ["."], "comma": [","]]
             ),
@@ -133,6 +139,7 @@ extension Test_URIParser {
             static let simpleUnexplode: Self = .init(name: "simpleUnexplode", config: .simpleUnexplode)
             static let formDataExplode: Self = .init(name: "formDataExplode", config: .formDataExplode)
             static let formDataUnexplode: Self = .init(name: "formDataUnexplode", config: .formDataUnexplode)
+            static let deepObjectExplode: Self = .init(name: "deepObjectExplode", config: .deepObjectExplode)
         }
         struct Variants {
 
@@ -161,6 +168,7 @@ extension Test_URIParser {
             var simpleUnexplode: Input
             var formDataExplode: Input
             var formDataUnexplode: Input
+            var deepObjectExplode: Input
         }
         var variants: Variants
         var value: URIParsedNode

--- a/Tests/OpenAPIRuntimeTests/URICoder/Serialization/Test_URISerializer.swift
+++ b/Tests/OpenAPIRuntimeTests/URICoder/Serialization/Test_URISerializer.swift
@@ -31,7 +31,8 @@ final class Test_URISerializer: Test_Runtime {
                     simpleExplode: "",
                     simpleUnexplode: "",
                     formDataExplode: "empty=",
-                    formDataUnexplode: "empty="
+                    formDataUnexplode: "empty=",
+                    deepObjectExplode: "empty="
                 )
             ),
             makeCase(
@@ -43,7 +44,8 @@ final class Test_URISerializer: Test_Runtime {
                     simpleExplode: "fred",
                     simpleUnexplode: "fred",
                     formDataExplode: "who=fred",
-                    formDataUnexplode: "who=fred"
+                    formDataUnexplode: "who=fred",
+                    deepObjectExplode: "who=fred"
                 )
             ),
             makeCase(
@@ -55,7 +57,8 @@ final class Test_URISerializer: Test_Runtime {
                     simpleExplode: "1234",
                     simpleUnexplode: "1234",
                     formDataExplode: "x=1234",
-                    formDataUnexplode: "x=1234"
+                    formDataUnexplode: "x=1234",
+                    deepObjectExplode: "x=1234"
                 )
             ),
             makeCase(
@@ -67,7 +70,8 @@ final class Test_URISerializer: Test_Runtime {
                     simpleExplode: "12.34",
                     simpleUnexplode: "12.34",
                     formDataExplode: "x=12.34",
-                    formDataUnexplode: "x=12.34"
+                    formDataUnexplode: "x=12.34",
+                    deepObjectExplode: "x=12.34"
                 )
             ),
             makeCase(
@@ -79,7 +83,8 @@ final class Test_URISerializer: Test_Runtime {
                     simpleExplode: "true",
                     simpleUnexplode: "true",
                     formDataExplode: "enabled=true",
-                    formDataUnexplode: "enabled=true"
+                    formDataUnexplode: "enabled=true",
+                    deepObjectExplode: "enabled=true"
                 )
             ),
             makeCase(
@@ -91,7 +96,8 @@ final class Test_URISerializer: Test_Runtime {
                     simpleExplode: "Hello%20World",
                     simpleUnexplode: "Hello%20World",
                     formDataExplode: "hello=Hello+World",
-                    formDataUnexplode: "hello=Hello+World"
+                    formDataUnexplode: "hello=Hello+World",
+                    deepObjectExplode: "hello=Hello%20World"
                 )
             ),
             makeCase(
@@ -103,7 +109,8 @@ final class Test_URISerializer: Test_Runtime {
                     simpleExplode: "red,green,blue",
                     simpleUnexplode: "red,green,blue",
                     formDataExplode: "list=red&list=green&list=blue",
-                    formDataUnexplode: "list=red,green,blue"
+                    formDataUnexplode: "list=red,green,blue",
+                    deepObjectExplode: nil
                 )
             ),
             makeCase(
@@ -118,7 +125,8 @@ final class Test_URISerializer: Test_Runtime {
                     simpleExplode: "comma=%2C,dot=.,semi=%3B",
                     simpleUnexplode: "comma,%2C,dot,.,semi,%3B",
                     formDataExplode: "comma=%2C&dot=.&semi=%3B",
-                    formDataUnexplode: "keys=comma,%2C,dot,.,semi,%3B"
+                    formDataUnexplode: "keys=comma,%2C,dot,.,semi,%3B",
+                    deepObjectExplode: "keys%5Bcomma%5D=%2C&keys%5Bdot%5D=.&keys%5Bsemi%5D=%3B"
                 )
             ),
         ]
@@ -140,6 +148,9 @@ final class Test_URISerializer: Test_Runtime {
             try testVariant(.simpleUnexplode, testCase.variants.simpleUnexplode)
             try testVariant(.formDataExplode, testCase.variants.formDataExplode)
             try testVariant(.formDataUnexplode, testCase.variants.formDataUnexplode)
+            if let deepObjectExplode = testCase.variants.deepObjectExplode {
+                try testVariant(.deepObjectExplode, deepObjectExplode)
+            }
         }
     }
 }
@@ -156,6 +167,7 @@ extension Test_URISerializer {
             static let simpleUnexplode: Self = .init(name: "simpleUnexplode", config: .simpleUnexplode)
             static let formDataExplode: Self = .init(name: "formDataExplode", config: .formDataExplode)
             static let formDataUnexplode: Self = .init(name: "formDataUnexplode", config: .formDataUnexplode)
+            static let deepObjectExplode: Self = .init(name: "deepObjectExplode", config: .deepObjectExplode)
         }
         struct Variants {
             var formExplode: String
@@ -164,6 +176,7 @@ extension Test_URISerializer {
             var simpleUnexplode: String
             var formDataExplode: String
             var formDataUnexplode: String
+            var deepObjectExplode: String?
         }
         var value: URIEncodedNode
         var key: String

--- a/Tests/OpenAPIRuntimeTests/URICoder/Test_URICodingRoundtrip.swift
+++ b/Tests/OpenAPIRuntimeTests/URICoder/Test_URICodingRoundtrip.swift
@@ -96,7 +96,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: "",
                 simpleUnexplode: "",
                 formDataExplode: "root=",
-                formDataUnexplode: "root="
+                formDataUnexplode: "root=",
+                deepObjectExplode: "root="
             )
         )
 
@@ -110,7 +111,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: "Hello%20World%21",
                 simpleUnexplode: "Hello%20World%21",
                 formDataExplode: "root=Hello+World%21",
-                formDataUnexplode: "root=Hello+World%21"
+                formDataUnexplode: "root=Hello+World%21",
+                deepObjectExplode: "root=Hello%20World%21"
             )
         )
 
@@ -124,7 +126,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: "red",
                 simpleUnexplode: "red",
                 formDataExplode: "root=red",
-                formDataUnexplode: "root=red"
+                formDataUnexplode: "root=red",
+                deepObjectExplode: "root=red"
             )
         )
 
@@ -138,7 +141,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: "1234",
                 simpleUnexplode: "1234",
                 formDataExplode: "root=1234",
-                formDataUnexplode: "root=1234"
+                formDataUnexplode: "root=1234",
+                deepObjectExplode: "root=1234"
             )
         )
 
@@ -152,7 +156,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: "12.34",
                 simpleUnexplode: "12.34",
                 formDataExplode: "root=12.34",
-                formDataUnexplode: "root=12.34"
+                formDataUnexplode: "root=12.34",
+                deepObjectExplode: "root=12.34"
             )
         )
 
@@ -166,7 +171,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: "true",
                 simpleUnexplode: "true",
                 formDataExplode: "root=true",
-                formDataUnexplode: "root=true"
+                formDataUnexplode: "root=true",
+                deepObjectExplode: "root=true"
             )
         )
 
@@ -180,7 +186,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: "2023-08-25T07%3A34%3A59Z",
                 simpleUnexplode: "2023-08-25T07%3A34%3A59Z",
                 formDataExplode: "root=2023-08-25T07%3A34%3A59Z",
-                formDataUnexplode: "root=2023-08-25T07%3A34%3A59Z"
+                formDataUnexplode: "root=2023-08-25T07%3A34%3A59Z",
+                deepObjectExplode: "root=2023-08-25T07%3A34%3A59Z"
             )
         )
 
@@ -194,7 +201,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: "a,b,c",
                 simpleUnexplode: "a,b,c",
                 formDataExplode: "list=a&list=b&list=c",
-                formDataUnexplode: "list=a,b,c"
+                formDataUnexplode: "list=a,b,c",
+                deepObjectExplode: nil
             )
         )
 
@@ -208,7 +216,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: "2023-08-25T07%3A34%3A59Z,2023-08-25T07%3A35%3A01Z",
                 simpleUnexplode: "2023-08-25T07%3A34%3A59Z,2023-08-25T07%3A35%3A01Z",
                 formDataExplode: "list=2023-08-25T07%3A34%3A59Z&list=2023-08-25T07%3A35%3A01Z",
-                formDataUnexplode: "list=2023-08-25T07%3A34%3A59Z,2023-08-25T07%3A35%3A01Z"
+                formDataUnexplode: "list=2023-08-25T07%3A34%3A59Z,2023-08-25T07%3A35%3A01Z",
+                deepObjectExplode: nil
             )
         )
 
@@ -222,7 +231,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: .custom("", value: [""]),
                 simpleUnexplode: .custom("", value: [""]),
                 formDataExplode: "",
-                formDataUnexplode: ""
+                formDataUnexplode: "",
+                deepObjectExplode: nil
             )
         )
 
@@ -236,7 +246,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: "red,green,blue",
                 simpleUnexplode: "red,green,blue",
                 formDataExplode: "list=red&list=green&list=blue",
-                formDataUnexplode: "list=red,green,blue"
+                formDataUnexplode: "list=red,green,blue",
+                deepObjectExplode: nil
             )
         )
 
@@ -250,7 +261,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: "bar=24,color=red,date=2023-08-25T07%3A34%3A59Z,empty=,foo=hi%21",
                 simpleUnexplode: "bar,24,color,red,date,2023-08-25T07%3A34%3A59Z,empty,,foo,hi%21",
                 formDataExplode: "bar=24&color=red&date=2023-08-25T07%3A34%3A59Z&empty=&foo=hi%21",
-                formDataUnexplode: "keys=bar,24,color,red,date,2023-08-25T07%3A34%3A59Z,empty,,foo,hi%21"
+                formDataUnexplode: "keys=bar,24,color,red,date,2023-08-25T07%3A34%3A59Z,empty,,foo,hi%21",
+                deepObjectExplode: "keys%5Bbar%5D=24&keys%5Bcolor%5D=red&keys%5Bdate%5D=2023-08-25T07%3A34%3A59Z&keys%5Bempty%5D=&keys%5Bfoo%5D=hi%21"
             )
         )
 
@@ -265,7 +277,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: "2023-01-18T10%3A04%3A11Z",
                 simpleUnexplode: "2023-01-18T10%3A04%3A11Z",
                 formDataExplode: "root=2023-01-18T10%3A04%3A11Z",
-                formDataUnexplode: "root=2023-01-18T10%3A04%3A11Z"
+                formDataUnexplode: "root=2023-01-18T10%3A04%3A11Z",
+                deepObjectExplode: "root=2023-01-18T10%3A04%3A11Z"
             )
         )
         try _test(
@@ -277,7 +290,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: "green",
                 simpleUnexplode: "green",
                 formDataExplode: "root=green",
-                formDataUnexplode: "root=green"
+                formDataUnexplode: "root=green",
+                deepObjectExplode: "root=green"
             )
         )
         try _test(
@@ -289,7 +303,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: "foo=bar",
                 simpleUnexplode: "foo,bar",
                 formDataExplode: "foo=bar",
-                formDataUnexplode: "root=foo,bar"
+                formDataUnexplode: "root=foo,bar",
+                deepObjectExplode: "root%5Bfoo%5D=bar"
             )
         )
 
@@ -304,7 +319,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: "",
                 simpleUnexplode: "",
                 formDataExplode: "",
-                formDataUnexplode: ""
+                formDataUnexplode: "",
+                deepObjectExplode: ""
             )
         )
 
@@ -318,7 +334,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: "bar=24,color=red,empty=,foo=hi%21",
                 simpleUnexplode: "bar,24,color,red,empty,,foo,hi%21",
                 formDataExplode: "bar=24&color=red&empty=&foo=hi%21",
-                formDataUnexplode: "keys=bar,24,color,red,empty,,foo,hi%21"
+                formDataUnexplode: "keys=bar,24,color,red,empty,,foo,hi%21",
+                deepObjectExplode: "keys%5Bbar%5D=24&keys%5Bcolor%5D=red&keys%5Bempty%5D=&keys%5Bfoo%5D=hi%21"
             )
         )
 
@@ -332,7 +349,8 @@ final class Test_URICodingRoundtrip: Test_Runtime {
                 simpleExplode: .custom("", value: ["": ""]),
                 simpleUnexplode: .custom("", value: ["": ""]),
                 formDataExplode: "",
-                formDataUnexplode: ""
+                formDataUnexplode: "",
+                deepObjectExplode: ""
             )
         )
     }
@@ -347,6 +365,7 @@ final class Test_URICodingRoundtrip: Test_Runtime {
         static let simpleUnexplode: Self = .init(name: "simpleUnexplode", configuration: .simpleUnexplode)
         static let formDataExplode: Self = .init(name: "formDataExplode", configuration: .formDataExplode)
         static let formDataUnexplode: Self = .init(name: "formDataUnexplode", configuration: .formDataUnexplode)
+        static let deepObjectExplode: Self = .init(name: "deepObjectExplode", configuration: .deepObjectExplode)
     }
     struct Variants<T: Codable & Equatable> {
 
@@ -370,6 +389,7 @@ final class Test_URICodingRoundtrip: Test_Runtime {
         var simpleUnexplode: Input
         var formDataExplode: Input
         var formDataUnexplode: Input
+        var deepObjectExplode: Input?
     }
 
     func _test<T: Codable & Equatable>(
@@ -397,6 +417,13 @@ final class Test_URICodingRoundtrip: Test_Runtime {
             configuration: .formDataUnexplode,
             variant: variants.formDataUnexplode
         )
+        
+        if let deepObjectExplode = variants.deepObjectExplode {
+            try testVariant(
+                name: "deepObjectExplode",
+                configuration: .deepObjectExplode,
+                variant: deepObjectExplode
+            )
+        }
     }
-
 }

--- a/Tests/OpenAPIRuntimeTests/URICoder/URICoderTestUtils.swift
+++ b/Tests/OpenAPIRuntimeTests/URICoder/URICoderTestUtils.swift
@@ -59,4 +59,11 @@ extension URICoderConfiguration {
         spaceEscapingCharacter: .plus,
         dateTranscoder: defaultDateTranscoder
     )
+    
+    static let deepObjectExplode: Self = .init(
+        style: .deepObject,
+        explode: true,
+        spaceEscapingCharacter: .percentEncoded,
+        dateTranscoder: defaultDateTranscoder
+    )
 }


### PR DESCRIPTION
### Motivation

The runtime changes for:
https://github.com/apple/swift-openapi-generator/issues/259

### Modifications

Added `deepObject` style to serializer & parser in order to support nested keys on query parameters.

### Result

Support nested keys on query parameters.

### Test Plan

These are just the runtime changes, tested together with generated changes.
