### PR TITLE
Fix empty additionalProperties dictionary encoding

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/CodableExtensions.swift
+++ b/Sources/OpenAPIRuntime/Conversion/CodableExtensions.swift
@@ -102,7 +102,6 @@
     /// - Parameter additionalProperties: A container of additional properties.
     /// - Throws: An error if there are issues with encoding the additional properties.
     public func encodeAdditionalProperties(_ additionalProperties: OpenAPIObjectContainer) throws {
-        guard !additionalProperties.value.isEmpty else { return }
         var container = container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties.value {
             try container.encode(OpenAPIValueContainer(unvalidatedValue: value), forKey: .init(key))
@@ -116,7 +115,6 @@
     /// - Parameter additionalProperties: A container of additional properties.
     /// - Throws: An error if there are issues with encoding the additional properties.
     public func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
-        guard !additionalProperties.isEmpty else { return }
         var container = container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties { try container.encode(value, forKey: .init(key)) }
     }


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apple/swift-openapi-generator/issues/525.

Turns out that the mere act of creating a decoding container is meaningful and we skipped it as an optimization, causing JSONDecoder to fail for empty dictionaries when used in additional properties.

### Modifications

Remove the extra guards that skipped creating a container, even when we already know there are no elements.

### Result

No more failures when encoding empty dictionaries in additionalProperties.

### Test Plan

Tested manually as this requirement seems to be coming out of JSONDecoder.
