### PR TITLE
Improve error message when encountering unexpected content-type headers

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/Converter+Common.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Common.swift
@@ -61,7 +61,12 @@ extension Converter {
         // The force unwrap is safe, we only get here if the array is not empty.
         let bestOption = evaluatedOptions.max { a, b in a.match.score < b.match.score }!
         let bestContentType = bestOption.contentType
-        if case .incompatible = bestOption.match { throw RuntimeError.unexpectedContentTypeHeader(bestContentType) }
+        if case .incompatible = bestOption.match {
+            throw RuntimeError.unexpectedContentTypeHeader(
+                expected: bestContentType,
+                received: String(describing: received)
+            )
+        }
         return bestContentType
     }
 

--- a/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
+++ b/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
@@ -37,7 +37,7 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
 
     // Headers
     case missingRequiredHeaderField(String)
-    case unexpectedContentTypeHeader(String)
+    case unexpectedContentTypeHeader(expected: String, received: String)
     case unexpectedAcceptHeader(String)
     case malformedAcceptHeader(String)
     case missingOrMalformedContentDispositionName
@@ -95,7 +95,8 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
             return
                 "Unsupported parameter style, parameter name: '\(name)', kind: \(location), style: \(style), explode: \(explode)"
         case .missingRequiredHeaderField(let name): return "The required header field named '\(name)' is missing."
-        case .unexpectedContentTypeHeader(let contentType): return "Unexpected Content-Type header: \(contentType)"
+        case .unexpectedContentTypeHeader(expected: let expected, received: let received):
+            return "Unexpected content type, expected: \(expected), received: \(received)"
         case .unexpectedAcceptHeader(let accept): return "Unexpected Accept header: \(accept)"
         case .malformedAcceptHeader(let accept): return "Malformed Accept header: \(accept)"
         case .missingOrMalformedContentDispositionName:

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-@_spi(Generated) import OpenAPIRuntime
+@testable @_spi(Generated) import OpenAPIRuntime
 import HTTPTypes
 
 extension HTTPField.Name { static var foo: Self { Self("foo")! } }
@@ -84,7 +84,16 @@ final class Test_CommonConverterExtensions: Test_Runtime {
         try testCase(received: "image/png", options: ["image/*", "*/*"], expected: "image/*")
         XCTAssertThrowsError(
             try testCase(received: "text/csv", options: ["text/html", "application/json"], expected: "-")
-        )
+        ) { error in
+            XCTAssert(error is RuntimeError)
+            guard let error = error as? RuntimeError,
+                case .unexpectedContentTypeHeader(expected: let expected, received: let received) = error,
+                expected == "text/html", received == "text/csv"
+            else {
+                XCTFail("Unexpected error: \(error)")
+                return
+            }
+        }
     }
 
     func testVerifyContentTypeIfPresent() throws {


### PR DESCRIPTION
### Motivation

When the server response has a content-type header that does not conform to the OpenAPI document, we currently throw an error. However, this error presents itself in a very confusing manner: it prints `Unexpected Content-Type header: application/json`, where `application/json is the _expected_ content-type. At best, this is ambiguous and potentially misleading.

### Modifications

- Extend `case RuntimeError.unexpectedContentTypeHeader` with _both_ the expected and received content-type associated values.
- Update the printed description to include both the expected and received content-type header values.

### Result

When an unexpected content-type is received, the error message is clearer.

### Test Plan

Updated the existing test that expects an error to check the error and that the error values are provided in the correct order.