### PR TITLE
Add support for empty arrays in form exploded query params

### DIFF
--- a/Sources/OpenAPIRuntime/URICoder/Common/URIEncodedNode.swift
+++ b/Sources/OpenAPIRuntime/URICoder/Common/URIEncodedNode.swift
@@ -20,8 +20,6 @@ enum URIEncodedNode: Equatable {
     /// No value.
     case unset
 
-    case emptyArray
-
     /// A single primitive value.
     case primitive(Primitive)
 
@@ -81,7 +79,7 @@ extension URIEncodedNode {
         switch self {
         case .unset: self = .primitive(value)
         case .primitive: throw InsertionError.settingPrimitiveValueAgain
-        case .emptyArray, .array, .dictionary: throw InsertionError.settingValueOnAContainer
+        case .array, .dictionary: throw InsertionError.settingValueOnAContainer
         }
     }
 

--- a/Sources/OpenAPIRuntime/URICoder/Common/URIEncodedNode.swift
+++ b/Sources/OpenAPIRuntime/URICoder/Common/URIEncodedNode.swift
@@ -20,6 +20,8 @@ enum URIEncodedNode: Equatable {
     /// No value.
     case unset
 
+    case emptyArray
+
     /// A single primitive value.
     case primitive(Primitive)
 
@@ -79,7 +81,7 @@ extension URIEncodedNode {
         switch self {
         case .unset: self = .primitive(value)
         case .primitive: throw InsertionError.settingPrimitiveValueAgain
-        case .array, .dictionary: throw InsertionError.settingValueOnAContainer
+        case .emptyArray, .array, .dictionary: throw InsertionError.settingValueOnAContainer
         }
     }
 

--- a/Sources/OpenAPIRuntime/URICoder/Encoding/URIValueToNodeEncoder.swift
+++ b/Sources/OpenAPIRuntime/URICoder/Encoding/URIValueToNodeEncoder.swift
@@ -71,6 +71,8 @@ final class URIValueToNodeEncoder {
         if let date = value as? Date {
             var container = singleValueContainer()
             try container.encode(date)
+        } else if (value as? Array<Any>)?.isEmpty == true {
+            currentStackEntry = CodingStackEntry(key: .init(stringValue: ""), storage: .emptyArray)
         } else {
             try value.encode(to: self)
         }

--- a/Sources/OpenAPIRuntime/URICoder/Encoding/URIValueToNodeEncoder.swift
+++ b/Sources/OpenAPIRuntime/URICoder/Encoding/URIValueToNodeEncoder.swift
@@ -72,7 +72,7 @@ final class URIValueToNodeEncoder {
             var container = singleValueContainer()
             try container.encode(date)
         } else if (value as? Array<Any>)?.isEmpty == true {
-            currentStackEntry = CodingStackEntry(key: .init(stringValue: ""), storage: .emptyArray)
+            currentStackEntry = CodingStackEntry(key: .init(stringValue: ""), storage: .array([]))
         } else {
             try value.encode(to: self)
         }

--- a/Sources/OpenAPIRuntime/URICoder/Serialization/URISerializer.swift
+++ b/Sources/OpenAPIRuntime/URICoder/Serialization/URISerializer.swift
@@ -126,7 +126,6 @@ extension URISerializer {
             case .deepObject: throw SerializationError.deepObjectsWithPrimitiveValuesNotSupported
             }
             try serializePrimitiveKeyValuePair(primitive, forKey: key, separator: keyAndValueSeparator)
-        case .emptyArray: try serializeArray([], forKey: key)
         case .array(let array): try serializeArray(array.map(unwrapPrimitiveValue), forKey: key)
         case .dictionary(let dictionary):
             try serializeDictionary(dictionary.mapValues(unwrapPrimitiveValue), forKey: key)

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Client.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Client.swift
@@ -56,6 +56,12 @@ final class Test_ClientConverterExtensions: Test_Runtime {
         XCTAssertEqual(request.soar_query, "search=foo&search=bar")
     }
 
+    func test_setQueryItemAsURI_arrayOfStrings_empty() throws {
+        var request = testRequest
+        try converter.setQueryItemAsURI(in: &request, style: .form, explode: true, name: "search", value: [String]())
+        XCTAssertEqual(request.soar_query, "search[]=")
+    }
+
     func test_setQueryItemAsURI_arrayOfStrings_unexploded() throws {
         var request = testRequest
         try converter.setQueryItemAsURI(

--- a/Tests/OpenAPIRuntimeTests/URICoder/Test_URICodingRoundtrip.swift
+++ b/Tests/OpenAPIRuntimeTests/URICoder/Test_URICodingRoundtrip.swift
@@ -235,11 +235,11 @@ final class Test_URICodingRoundtrip: Test_Runtime {
             [] as [String],
             key: "list",
             .init(
-                formExplode: "",
+                formExplode: "list[]=",
                 formUnexplode: "",
                 simpleExplode: .custom("", value: [""]),
                 simpleUnexplode: .custom("", value: [""]),
-                formDataExplode: "",
+                formDataExplode: "list[]=",
                 formDataUnexplode: "",
                 deepObjectExplode: .custom("", expectedError: .deepObjectsArrayNotSupported)
             )


### PR DESCRIPTION
Fixes https://github.com/apple/swift-openapi-generator/issues/570.
