### PR TITLE
Swift 6 prep - Part 1

### DIFF
--- a/Sources/OpenAPIRuntime/Base/OpenAPIMIMEType.swift
+++ b/Sources/OpenAPIRuntime/Base/OpenAPIMIMEType.swift
@@ -14,13 +14,13 @@
 import Foundation
 
 /// A container for a parsed, valid MIME type.
-@_spi(Generated) public struct OpenAPIMIMEType: Equatable {
+@_spi(Generated) public struct OpenAPIMIMEType: Equatable, Sendable {
 
     /// XML MIME type
     public static let xml: OpenAPIMIMEType = .init(kind: .concrete(type: "application", subtype: "xml"))
 
     /// The kind of the MIME type.
-    public enum Kind: Equatable {
+    public enum Kind: Equatable, Sendable {
 
         /// Any, spelled as `*/*`.
         case any

--- a/Tests/OpenAPIRuntimeTests/Base/Test_ContentDisposition.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_ContentDisposition.swift
@@ -21,7 +21,7 @@ final class Test_ContentDisposition: Test_Runtime {
             input: String,
             parsed: ContentDisposition?,
             output: String?,
-            file: StaticString = #file,
+            file: StaticString = #filePath,
             line: UInt = #line
         ) {
             let value = ContentDisposition(rawValue: input)

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIMIMEType.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIMIMEType.swift
@@ -88,7 +88,7 @@ final class Test_OpenAPIMIMEType: Test_Runtime {
             receivedParameters: [String: String],
             against option: OpenAPIMIMEType,
             expected expectedMatch: OpenAPIMIMEType.Match,
-            file: StaticString = #file,
+            file: StaticString = #filePath,
             line: UInt = #line
         ) {
             let result = OpenAPIMIMEType.evaluate(
@@ -109,7 +109,7 @@ final class Test_OpenAPIMIMEType: Test_Runtime {
         func testJSONWith2Params(
             against option: OpenAPIMIMEType,
             expected expectedMatch: OpenAPIMIMEType.Match,
-            file: StaticString = #file,
+            file: StaticString = #filePath,
             line: UInt = #line
         ) {
             testCase(

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
@@ -26,7 +26,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
             received: String?,
             options: [String],
             expected expectedChoice: String,
-            file: StaticString = #file,
+            file: StaticString = #filePath,
             line: UInt = #line
         ) throws {
             let choice = try converter.bestContentType(received: received.map { .init($0)! }, options: options)
@@ -109,7 +109,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
     }
 
     func testExtractContentDispositionNameAndFilename() throws {
-        func testCase(value: String?, name: String?, filename: String?, file: StaticString = #file, line: UInt = #line)
+        func testCase(value: String?, name: String?, filename: String?, file: StaticString = #filePath, line: UInt = #line)
             throws
         {
             let headerFields: HTTPFields

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
@@ -109,9 +109,13 @@ final class Test_CommonConverterExtensions: Test_Runtime {
     }
 
     func testExtractContentDispositionNameAndFilename() throws {
-        func testCase(value: String?, name: String?, filename: String?, file: StaticString = #filePath, line: UInt = #line)
-            throws
-        {
+        func testCase(
+            value: String?,
+            name: String?,
+            filename: String?,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) throws {
             let headerFields: HTTPFields
             if let value { headerFields = [.contentDisposition: value] } else { headerFields = [:] }
             let (actualName, actualFilename) = try converter.extractContentDispositionNameAndFilename(in: headerFields)

--- a/Tests/OpenAPIRuntimeTests/EventStreams/Test_ServerSentEventsDecoding.swift
+++ b/Tests/OpenAPIRuntimeTests/EventStreams/Test_ServerSentEventsDecoding.swift
@@ -16,7 +16,7 @@ import XCTest
 import Foundation
 
 final class Test_ServerSentEventsDecoding: Test_Runtime {
-    func _test(input: String, output: [ServerSentEvent], file: StaticString = #file, line: UInt = #line) async throws {
+    func _test(input: String, output: [ServerSentEvent], file: StaticString = #filePath, line: UInt = #line) async throws {
         let sequence = asOneBytePerElementSequence(ArraySlice(input.utf8)).asDecodedServerSentEvents()
         let events = try await [ServerSentEvent](collecting: sequence)
         XCTAssertEqual(events.count, output.count, file: file, line: line)
@@ -85,7 +85,7 @@ final class Test_ServerSentEventsDecoding: Test_Runtime {
     func _testJSONData<JSONType: Decodable & Hashable & Sendable>(
         input: String,
         output: [ServerSentEventWithJSONData<JSONType>],
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) async throws {
         let sequence = asOneBytePerElementSequence(ArraySlice(input.utf8))
@@ -123,7 +123,7 @@ final class Test_ServerSentEventsDecoding: Test_Runtime {
 }
 
 final class Test_ServerSentEventsDecoding_Lines: Test_Runtime {
-    func _test(input: String, output: [String], file: StaticString = #file, line: UInt = #line) async throws {
+    func _test(input: String, output: [String], file: StaticString = #filePath, line: UInt = #line) async throws {
         let upstream = asOneBytePerElementSequence(ArraySlice(input.utf8))
         let sequence = ServerSentEventsLineDeserializationSequence(upstream: upstream)
         let lines = try await [ArraySlice<UInt8>](collecting: sequence)

--- a/Tests/OpenAPIRuntimeTests/EventStreams/Test_ServerSentEventsDecoding.swift
+++ b/Tests/OpenAPIRuntimeTests/EventStreams/Test_ServerSentEventsDecoding.swift
@@ -16,7 +16,9 @@ import XCTest
 import Foundation
 
 final class Test_ServerSentEventsDecoding: Test_Runtime {
-    func _test(input: String, output: [ServerSentEvent], file: StaticString = #filePath, line: UInt = #line) async throws {
+    func _test(input: String, output: [ServerSentEvent], file: StaticString = #filePath, line: UInt = #line)
+        async throws
+    {
         let sequence = asOneBytePerElementSequence(ArraySlice(input.utf8)).asDecodedServerSentEvents()
         let events = try await [ServerSentEvent](collecting: sequence)
         XCTAssertEqual(events.count, output.count, file: file, line: line)

--- a/Tests/OpenAPIRuntimeTests/EventStreams/Test_ServerSentEventsEncoding.swift
+++ b/Tests/OpenAPIRuntimeTests/EventStreams/Test_ServerSentEventsEncoding.swift
@@ -16,7 +16,7 @@ import XCTest
 import Foundation
 
 final class Test_ServerSentEventsEncoding: Test_Runtime {
-    func _test(input: [ServerSentEvent], output: String, file: StaticString = #file, line: UInt = #line) async throws {
+    func _test(input: [ServerSentEvent], output: String, file: StaticString = #filePath, line: UInt = #line) async throws {
         let sequence = WrappedSyncSequence(sequence: input).asEncodedServerSentEvents()
         try await XCTAssertEqualAsyncData(sequence, output.utf8, file: file, line: line)
     }
@@ -73,7 +73,7 @@ final class Test_ServerSentEventsEncoding: Test_Runtime {
     func _testJSONData<JSONType: Encodable & Hashable & Sendable>(
         input: [ServerSentEventWithJSONData<JSONType>],
         output: String,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) async throws {
         let sequence = WrappedSyncSequence(sequence: input).asEncodedServerSentEventsWithJSONData()

--- a/Tests/OpenAPIRuntimeTests/EventStreams/Test_ServerSentEventsEncoding.swift
+++ b/Tests/OpenAPIRuntimeTests/EventStreams/Test_ServerSentEventsEncoding.swift
@@ -16,7 +16,9 @@ import XCTest
 import Foundation
 
 final class Test_ServerSentEventsEncoding: Test_Runtime {
-    func _test(input: [ServerSentEvent], output: String, file: StaticString = #filePath, line: UInt = #line) async throws {
+    func _test(input: [ServerSentEvent], output: String, file: StaticString = #filePath, line: UInt = #line)
+        async throws
+    {
         let sequence = WrappedSyncSequence(sequence: input).asEncodedServerSentEvents()
         try await XCTAssertEqualAsyncData(sequence, output.utf8, file: file, line: line)
     }

--- a/Tests/OpenAPIRuntimeTests/Interface/Test_HTTPBody.swift
+++ b/Tests/OpenAPIRuntimeTests/Interface/Test_HTTPBody.swift
@@ -229,14 +229,14 @@ final class Test_Body: Test_Runtime {
 }
 
 extension Test_Body {
-    func _testConsume(_ body: HTTPBody, expected: HTTPBody.ByteChunk, file: StaticString = #file, line: UInt = #line)
+    func _testConsume(_ body: HTTPBody, expected: HTTPBody.ByteChunk, file: StaticString = #filePath, line: UInt = #line)
         async throws
     {
         let output = try await ArraySlice(collecting: body, upTo: .max)
         XCTAssertEqual(output, expected, file: file, line: line)
     }
 
-    func _testConsume(_ body: HTTPBody, expected: some StringProtocol, file: StaticString = #file, line: UInt = #line)
+    func _testConsume(_ body: HTTPBody, expected: some StringProtocol, file: StaticString = #filePath, line: UInt = #line)
         async throws
     {
         let output = try await String(collecting: body, upTo: .max)

--- a/Tests/OpenAPIRuntimeTests/Interface/Test_HTTPBody.swift
+++ b/Tests/OpenAPIRuntimeTests/Interface/Test_HTTPBody.swift
@@ -229,16 +229,22 @@ final class Test_Body: Test_Runtime {
 }
 
 extension Test_Body {
-    func _testConsume(_ body: HTTPBody, expected: HTTPBody.ByteChunk, file: StaticString = #filePath, line: UInt = #line)
-        async throws
-    {
+    func _testConsume(
+        _ body: HTTPBody,
+        expected: HTTPBody.ByteChunk,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
         let output = try await ArraySlice(collecting: body, upTo: .max)
         XCTAssertEqual(output, expected, file: file, line: line)
     }
 
-    func _testConsume(_ body: HTTPBody, expected: some StringProtocol, file: StaticString = #filePath, line: UInt = #line)
-        async throws
-    {
+    func _testConsume(
+        _ body: HTTPBody,
+        expected: some StringProtocol,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
         let output = try await String(collecting: body, upTo: .max)
         XCTAssertEqual(output, expected.description, file: file, line: line)
     }

--- a/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
+++ b/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
@@ -237,7 +237,7 @@ struct MockCustomCoder: CustomCoder {
 ///   - rhs: The expected absolute string representation.
 ///   - file: The file name to include in the failure message (default is the source file where this function is called).
 ///   - line: The line number to include in the failure message (default is the line where this function is called).
-public func XCTAssertEqualURLString(_ lhs: URL?, _ rhs: String, file: StaticString = #file, line: UInt = #line) {
+public func XCTAssertEqualURLString(_ lhs: URL?, _ rhs: String, file: StaticString = #filePath, line: UInt = #line) {
     guard let lhs else {
         XCTFail("URL is nil")
         return

--- a/Tests/OpenAPIRuntimeTests/URICoder/Decoder/Test_URIValueFromNodeDecoder.swift
+++ b/Tests/OpenAPIRuntimeTests/URICoder/Decoder/Test_URIValueFromNodeDecoder.swift
@@ -81,7 +81,7 @@ final class Test_URIValueFromNodeDecoder: Test_Runtime {
             key: String,
             style: URICoderConfiguration.Style = .form,
             explode: Bool = true,
-            file: StaticString = #file,
+            file: StaticString = #filePath,
             line: UInt = #line
         ) throws {
             let decoder = URIValueFromNodeDecoder(

--- a/Tests/OpenAPIRuntimeTests/URICoder/Test_URICodingRoundtrip.swift
+++ b/Tests/OpenAPIRuntimeTests/URICoder/Test_URICodingRoundtrip.swift
@@ -418,7 +418,7 @@ final class Test_URICodingRoundtrip: Test_Runtime {
         _ value: T,
         key: String,
         _ variants: Variants<T>,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
         func testVariant(name: String, configuration: URICoderConfiguration, variant: Variants<T>.Input) throws {


### PR DESCRIPTION
### Motivation

Fixes to get closer to building in Swift 6 mode without diagnostics.

### Modifications

- Made two public types Sendable
- s/#file/#filePath in tests

### Result

Builds with fewer warnings when trying Swift 6 mode (will open another PR for the remaining work).

### Test Plan

Unit tests passed.
