### PR TITLE
Support NSNull in OpenAPIContainer types

### DIFF
--- a/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
+++ b/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Foundation)
+#if canImport(Darwin)
 import class Foundation.NSNull
+#else
+@preconcurrency import class Foundation.NSNull
+#endif
 #endif
 
 /// A container for a value represented by JSON Schema.

--- a/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
+++ b/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
@@ -12,6 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Foundation)
+import class Foundation.NSNull
+#endif
+
 /// A container for a value represented by JSON Schema.
 ///
 /// Contains an untyped JSON value. In some cases, the structure of the data
@@ -62,6 +66,9 @@ public struct OpenAPIValueContainer: Codable, Hashable, Sendable {
     /// - Throws: When the value is not supported.
     static func tryCast(_ value: (any Sendable)?) throws -> (any Sendable)? {
         guard let value = value else { return nil }
+        #if canImport(Foundation)
+        if value is NSNull { return value }
+        #endif
         if let array = value as? [(any Sendable)?] { return try array.map(tryCast(_:)) }
         if let dictionary = value as? [String: (any Sendable)?] { return try dictionary.mapValues(tryCast(_:)) }
         if let value = tryCastPrimitiveType(value) { return value }
@@ -123,6 +130,12 @@ public struct OpenAPIValueContainer: Codable, Hashable, Sendable {
             try container.encodeNil()
             return
         }
+        #if canImport(Foundation)
+        if value is NSNull {
+            try container.encodeNil()
+            return
+        }
+        #endif
         switch value {
         case let value as Bool: try container.encode(value)
         case let value as Int: try container.encode(value)

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -12,6 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
+#if canImport(Foundation)
+import Foundation
+#endif
 @_spi(Generated) @testable import OpenAPIRuntime
 
 final class Test_OpenAPIValue: Test_Runtime {
@@ -21,6 +24,10 @@ final class Test_OpenAPIValue: Test_Runtime {
         _ = OpenAPIValueContainer(true)
         _ = OpenAPIValueContainer(1)
         _ = OpenAPIValueContainer(4.5)
+
+        #if canImport(Foundation)
+        XCTAssertEqual(try OpenAPIValueContainer(unvalidatedValue: NSNull()).value as? NSNull, NSNull())
+        #endif
 
         _ = try OpenAPIValueContainer(unvalidatedValue: ["hello"])
         _ = try OpenAPIValueContainer(unvalidatedValue: ["hello": "world"])
@@ -60,6 +67,16 @@ final class Test_OpenAPIValue: Test_Runtime {
             """#
         try _testPrettyEncoded(container, expectedJSON: expectedString)
     }
+    #if canImport(Foundation)
+    func testEncodingNSNull() throws {
+        let value = NSNull()
+        let container = try OpenAPIValueContainer(unvalidatedValue: value)
+        let expectedString = #"""
+            null
+            """#
+        try _testPrettyEncoded(container, expectedJSON: expectedString)
+    }
+    #endif
 
     func testEncoding_container_failure() throws {
         struct Foobar: Equatable {}

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 import XCTest
 #if canImport(Foundation)
-import Foundation
+#if canImport(Darwin)
+import class Foundation.NSNull
+#else
+@preconcurrency import class Foundation.NSNull
+#endif
 #endif
 @_spi(Generated) @testable import OpenAPIRuntime
 


### PR DESCRIPTION
### Motivation

When receiving containers from adopter code, there might be NSNull values, which represent a nil value.

Previously, this value would not be treated as nil, instead it'd throw an error as an unrecognized type.

### Modifications

Handle NSNull and treat it as nil.

### Result

You can provide a container with an NSNull nested value and it'll get encoded correctly.

### Test Plan

Added a unit test.
