### PR TITLE
Improved encoding of NSNumber in OpenAPIValueContainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ DerivedData/
 /Package.resolved
 .ci/
 .docc-build/
+.swiftpm

--- a/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
+++ b/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Foundation)
+#if canImport(Darwin)
 import class Foundation.NSNull
+#else
+@preconcurrency import class Foundation.NSNull
+#endif
 #endif
 
 /// A container for a value represented by JSON Schema.

--- a/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
+++ b/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
@@ -166,13 +166,19 @@ public struct OpenAPIValueContainer: Codable, Hashable, Sendable {
     /// - Parameters:
     ///   - value: The NSNumber that boxes one of possibly many different types of values.
     ///   - container: The container to encode the value in.
+    /// - Throws: An error if the encoding process encounters issues or if the value is invalid.
     private func encode(_ value: NSNumber, to container: inout any SingleValueEncodingContainer) throws {
         if value === kCFBooleanTrue {
             try container.encode(true)
         } else if value === kCFBooleanFalse {
             try container.encode(false)
         } else {
-            let type = CFNumberGetType(value)
+            #if canImport(ObjectiveC)
+            let nsNumber = value as CFNumber
+            #else
+            let nsNumber = unsafeBitCast(value, to: CFNumber.self)
+            #endif
+            let type = CFNumberGetType(nsNumber)
             switch type {
             case .sInt8Type, .charType: try container.encode(value.int8Value)
             case .sInt16Type, .shortType: try container.encode(value.int16Value)

--- a/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
+++ b/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
@@ -12,6 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Foundation)
+import class Foundation.NSNull
+#endif
+
 /// A container for a value represented by JSON Schema.
 ///
 /// Contains an untyped JSON value. In some cases, the structure of the data
@@ -62,6 +66,9 @@ public struct OpenAPIValueContainer: Codable, Hashable, Sendable {
     /// - Throws: When the value is not supported.
     static func tryCast(_ value: (any Sendable)?) throws -> (any Sendable)? {
         guard let value = value else { return nil }
+        #if canImport(Foundation)
+        if value is NSNull { return value }
+        #endif
         if let array = value as? [(any Sendable)?] { return try array.map(tryCast(_:)) }
         if let dictionary = value as? [String: (any Sendable)?] { return try dictionary.mapValues(tryCast(_:)) }
         if let value = tryCastPrimitiveType(value) { return value }
@@ -123,6 +130,12 @@ public struct OpenAPIValueContainer: Codable, Hashable, Sendable {
             try container.encodeNil()
             return
         }
+        #if canImport(Foundation)
+        if value is NSNull {
+            try container.encodeNil()
+            return
+        }
+        #endif
         switch value {
         case let value as Bool: try container.encode(value)
         case let value as Int: try container.encode(value)

--- a/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
+++ b/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
@@ -18,6 +18,8 @@ import class Foundation.NSNull
 #else
 @preconcurrency import class Foundation.NSNull
 #endif
+import class Foundation.NSNumber
+import CoreFoundation
 #endif
 
 /// A container for a value represented by JSON Schema.
@@ -139,6 +141,10 @@ public struct OpenAPIValueContainer: Codable, Hashable, Sendable {
             try container.encodeNil()
             return
         }
+        if let nsNumber = value as? NSNumber {
+            try encode(nsNumber, to: &container)
+            return
+        }
         #endif
         switch value {
         case let value as Bool: try container.encode(value)
@@ -154,6 +160,36 @@ public struct OpenAPIValueContainer: Codable, Hashable, Sendable {
                 value,
                 .init(codingPath: container.codingPath, debugDescription: "OpenAPIValueContainer cannot be encoded")
             )
+        }
+    }
+    /// Encodes the provided NSNumber based on its internal representation.
+    /// - Parameters:
+    ///   - value: The NSNumber that boxes one of possibly many different types of values.
+    ///   - container: The container to encode the value in.
+    private func encode(_ value: NSNumber, to container: inout any SingleValueEncodingContainer) throws {
+        if value === kCFBooleanTrue {
+            try container.encode(true)
+        } else if value === kCFBooleanFalse {
+            try container.encode(false)
+        } else {
+            let type = CFNumberGetType(value)
+            switch type {
+            case .sInt8Type, .charType: try container.encode(value.int8Value)
+            case .sInt16Type, .shortType: try container.encode(value.int16Value)
+            case .sInt32Type, .intType: try container.encode(value.int32Value)
+            case .sInt64Type, .longLongType: try container.encode(value.int64Value)
+            case .float32Type, .floatType: try container.encode(value.floatValue)
+            case .float64Type, .doubleType, .cgFloatType: try container.encode(value.doubleValue)
+            case .nsIntegerType, .longType, .cfIndexType: try container.encode(value.intValue)
+            default:
+                throw EncodingError.invalidValue(
+                    value,
+                    .init(
+                        codingPath: container.codingPath,
+                        debugDescription: "OpenAPIValueContainer cannot encode NSNumber of the underlying type: \(type)"
+                    )
+                )
+            }
         }
     }
 

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -13,12 +13,7 @@
 //===----------------------------------------------------------------------===//
 import XCTest
 #if canImport(Foundation)
-#if canImport(Darwin)
-import class Foundation.NSNull
-#else
-@preconcurrency import class Foundation.NSNull
-#endif
-import Foundation
+@preconcurrency import Foundation
 import CoreFoundation
 #endif
 @_spi(Generated) @testable import OpenAPIRuntime
@@ -84,6 +79,19 @@ final class Test_OpenAPIValue: Test_Runtime {
     }
 
     func testEncodingNSNumber() throws {
+        func assertEncodedCF(
+            _ value: CFNumber,
+            as encodedValue: String,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) throws {
+            #if canImport(ObjectiveC)
+            let nsNumber = value as NSNumber
+            #else
+            let nsNumber = unsafeBitCast(self, to: NSNumber.self)
+            #endif
+            try assertEncoded(nsNumber, as: encodedValue, file: file, line: line)
+        }
         func assertEncoded(
             _ value: NSNumber,
             as encodedValue: String,
@@ -108,15 +116,17 @@ final class Test_OpenAPIValue: Test_Runtime {
         try assertEncoded(NSNumber(value: 24 as UInt32), as: "24")
         try assertEncoded(NSNumber(value: 24 as UInt64), as: "24")
         try assertEncoded(NSNumber(value: 24 as UInt), as: "24")
+        #if canImport(ObjectiveC)
         try assertEncoded(NSNumber(value: 24 as NSInteger), as: "24")
+        #endif
         try assertEncoded(NSNumber(value: 24 as CFIndex), as: "24")
         try assertEncoded(NSNumber(value: 24.1 as Float32), as: "24.1")
         try assertEncoded(NSNumber(value: 24.1 as Float64), as: "24.1")
         try assertEncoded(NSNumber(value: 24.1 as Float), as: "24.1")
         try assertEncoded(NSNumber(value: 24.1 as Double), as: "24.1")
-        XCTAssertThrowsError(try assertEncoded(kCFNumberNaN, as: "-"))
-        XCTAssertThrowsError(try assertEncoded(kCFNumberNegativeInfinity, as: "-"))
-        XCTAssertThrowsError(try assertEncoded(kCFNumberPositiveInfinity, as: "-"))
+        XCTAssertThrowsError(try assertEncodedCF(kCFNumberNaN, as: "-"))
+        XCTAssertThrowsError(try assertEncodedCF(kCFNumberNegativeInfinity, as: "-"))
+        XCTAssertThrowsError(try assertEncodedCF(kCFNumberPositiveInfinity, as: "-"))
     }
     #endif
     func testEncoding_container_failure() throws {

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -12,6 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
+import Foundation
+import CoreFoundation
+
 #if canImport(Foundation)
 #if canImport(Darwin)
 import class Foundation.NSNull
@@ -80,8 +83,43 @@ final class Test_OpenAPIValue: Test_Runtime {
             """#
         try _testPrettyEncoded(container, expectedJSON: expectedString)
     }
-    #endif
 
+    func testEncodingNSNumber() throws {
+        func assertEncoded(
+            _ value: NSNumber,
+            as encodedValue: String,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) throws {
+            let container = try OpenAPIValueContainer(unvalidatedValue: value)
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .sortedKeys
+            let data = try encoder.encode(container)
+            XCTAssertEqual(String(decoding: data, as: UTF8.self), encodedValue, file: file, line: line)
+        }
+        try assertEncoded(NSNumber(value: true as Bool), as: "true")
+        try assertEncoded(NSNumber(value: false as Bool), as: "false")
+        try assertEncoded(NSNumber(value: 24 as Int8), as: "24")
+        try assertEncoded(NSNumber(value: 24 as Int16), as: "24")
+        try assertEncoded(NSNumber(value: 24 as Int32), as: "24")
+        try assertEncoded(NSNumber(value: 24 as Int64), as: "24")
+        try assertEncoded(NSNumber(value: 24 as Int), as: "24")
+        try assertEncoded(NSNumber(value: 24 as UInt8), as: "24")
+        try assertEncoded(NSNumber(value: 24 as UInt16), as: "24")
+        try assertEncoded(NSNumber(value: 24 as UInt32), as: "24")
+        try assertEncoded(NSNumber(value: 24 as UInt64), as: "24")
+        try assertEncoded(NSNumber(value: 24 as UInt), as: "24")
+        try assertEncoded(NSNumber(value: 24 as NSInteger), as: "24")
+        try assertEncoded(NSNumber(value: 24 as CFIndex), as: "24")
+        try assertEncoded(NSNumber(value: 24.1 as Float32), as: "24.1")
+        try assertEncoded(NSNumber(value: 24.1 as Float64), as: "24.1")
+        try assertEncoded(NSNumber(value: 24.1 as Float), as: "24.1")
+        try assertEncoded(NSNumber(value: 24.1 as Double), as: "24.1")
+        XCTAssertThrowsError(try assertEncoded(kCFNumberNaN, as: "-"))
+        XCTAssertThrowsError(try assertEncoded(kCFNumberNegativeInfinity, as: "-"))
+        XCTAssertThrowsError(try assertEncoded(kCFNumberPositiveInfinity, as: "-"))
+    }
+    #endif
     func testEncoding_container_failure() throws {
         struct Foobar: Equatable {}
         XCTAssertThrowsError(try OpenAPIValueContainer(unvalidatedValue: Foobar())) { error in

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -12,6 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
+#if canImport(Foundation)
+import Foundation
+#endif
 @_spi(Generated) @testable import OpenAPIRuntime
 
 final class Test_OpenAPIValue: Test_Runtime {
@@ -21,6 +24,10 @@ final class Test_OpenAPIValue: Test_Runtime {
         _ = OpenAPIValueContainer(true)
         _ = OpenAPIValueContainer(1)
         _ = OpenAPIValueContainer(4.5)
+
+        #if canImport(Foundation)
+        XCTAssertEqual(try OpenAPIValueContainer(unvalidatedValue: NSNull()).value as? NSNull, NSNull())
+        #endif
 
         _ = try OpenAPIValueContainer(unvalidatedValue: ["hello"])
         _ = try OpenAPIValueContainer(unvalidatedValue: ["hello": "world"])
@@ -60,6 +67,16 @@ final class Test_OpenAPIValue: Test_Runtime {
             """#
         try _testPrettyEncoded(container, expectedJSON: expectedString)
     }
+    #if canImport(Foundation)
+    func testEncodingNSNull() throws {
+        let value = NSNull()
+        let container = try OpenAPIValueContainer(unvalidatedValue: value)
+        let expectedString = #"""
+            null
+            """#
+        try _testPrettyEncoded(container, expectedJSON: expectedString)
+    }
+    #endif
 
     func testEncoding_container_failure() throws {
         struct Foobar: Equatable {}

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 import XCTest
 #if canImport(Foundation)
-import Foundation
+#if canImport(Darwin)
+import class Foundation.NSNull
+#else
+@preconcurrency import class Foundation.NSNull
+#endif
 #endif
 @_spi(Generated) @testable import OpenAPIRuntime
 


### PR DESCRIPTION
### Motivation

When getting CoreFoundation/Foundation types, especially numbers, they automatically bridge to Swift types like Bool, Int, etc. That casting is pretty flexible, and allows e.g. casting a number into a boolean, which isn't desired when encoding into JSON, as `false` and `0` represent very different values.

Previously, we relied on the automatic casting to know how to encode values, however that produced incorrect results in some cases.

### Modifications

Add explicit handling of CF/NS types and try to encode using that new method before falling back to testing for native Swift types. This ensures that the original intention of the creator of the CF/NS types doesn't get lost in encoding.

### Result

Correct encoding into JSON of types produced in the CF/NS world, like JSONSerialization.

### Test Plan

Added unit tests.
