### PR TITLE
EventStreams: Customisable Terminating Byte Sequence

### DIFF
--- a/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
+++ b/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
@@ -89,10 +89,9 @@ extension AsyncSequence where Element == ArraySlice<UInt8>, Self: Sendable {
     }
 }
 
-extension ServerSentEventsDeserializationSequence<Upstream: AsyncSequence & Sendable>: Sendable
-where Upstream.Element == ArraySlice<UInt8> {
+extension ServerSentEventsDeserializationSequence {
     /// Creates a new sequence.
     /// - Parameter upstream: The upstream sequence of arbitrary byte chunks.
     @available(*, deprecated, renamed: "init(upstream:while:)")
-    @_disfavoredOverload public init(upstream: Upstream) { init(upstream: upstream, while: { _ in true }) }
+    @_disfavoredOverload public init(upstream: Upstream) { self.init(upstream: upstream, while: { _ in true }) }
 }

--- a/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
+++ b/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
@@ -59,3 +59,14 @@ extension Configuration {
         )
     }
 }
+
+extension AsyncSequence where Element == ArraySlice<UInt8>, Self: Sendable {
+    /// Returns another sequence that decodes each event's data as the provided type using the provided decoder.
+    ///
+    /// Use this method if the event's `data` field is not JSON, or if you don't want to parse it using `asDecodedServerSentEventsWithJSONData`.
+    /// - Returns: A sequence that provides the events.
+    @available(*, deprecated, renamed: "asDecodedServerSentEvents(while:)")
+    @_disfavoredOverload public func asDecodedServerSentEvents() -> ServerSentEventsDeserializationSequence<
+        ServerSentEventsLineDeserializationSequence<Self>
+    > { asDecodedServerSentEvents(while: { _ in true }) }
+}

--- a/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
+++ b/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
@@ -88,3 +88,11 @@ extension AsyncSequence where Element == ArraySlice<UInt8>, Self: Sendable {
         asDecodedServerSentEventsWithJSONData(of: dataType, decoder: decoder, while: { _ in true })
     }
 }
+
+extension ServerSentEventsDeserializationSequence<Upstream: AsyncSequence & Sendable>: Sendable
+where Upstream.Element == ArraySlice<UInt8> {
+    /// Creates a new sequence.
+    /// - Parameter upstream: The upstream sequence of arbitrary byte chunks.
+    @available(*, deprecated, renamed: "init(upstream:while:)")
+    @_disfavoredOverload public init(upstream: Upstream) { init(upstream: upstream, while: { _ in true }) }
+}

--- a/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
+++ b/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
@@ -69,4 +69,22 @@ extension AsyncSequence where Element == ArraySlice<UInt8>, Self: Sendable {
     @_disfavoredOverload public func asDecodedServerSentEvents() -> ServerSentEventsDeserializationSequence<
         ServerSentEventsLineDeserializationSequence<Self>
     > { asDecodedServerSentEvents(while: { _ in true }) }
+    
+    /// Returns another sequence that decodes each event's data as the provided type using the provided decoder.
+    ///
+    /// Use this method if the event's `data` field is JSON.
+    /// - Parameters:
+    ///   - dataType: The type to decode the JSON data into.
+    ///   - decoder: The JSON decoder to use.
+    /// - Returns: A sequence that provides the events with the decoded JSON data.
+    @available(*, deprecated, renamed: "asDecodedServerSentEventsWithJSONData(of:decoder:while:)")
+    @_disfavoredOverload public func asDecodedServerSentEventsWithJSONData<JSONDataType: Decodable>(
+        of dataType: JSONDataType.Type = JSONDataType.self,
+        decoder: JSONDecoder = .init()
+    ) -> AsyncThrowingMapSequence<
+        ServerSentEventsDeserializationSequence<ServerSentEventsLineDeserializationSequence<Self>>,
+        ServerSentEventWithJSONData<JSONDataType>
+    > {
+        asDecodedServerSentEventsWithJSONData(of: dataType, decoder: decoder, while: { _ in true })
+    }
 }

--- a/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
+++ b/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
@@ -65,11 +65,10 @@ extension AsyncSequence where Element == ArraySlice<UInt8>, Self: Sendable {
     ///
     /// Use this method if the event's `data` field is not JSON, or if you don't want to parse it using `asDecodedServerSentEventsWithJSONData`.
     /// - Returns: A sequence that provides the events.
-    @available(*, deprecated, renamed: "asDecodedServerSentEvents(while:)")
-    @_disfavoredOverload public func asDecodedServerSentEvents() -> ServerSentEventsDeserializationSequence<
+    @available(*, deprecated, renamed: "asDecodedServerSentEvents(while:)") @_disfavoredOverload
+    public func asDecodedServerSentEvents() -> ServerSentEventsDeserializationSequence<
         ServerSentEventsLineDeserializationSequence<Self>
     > { asDecodedServerSentEvents(while: { _ in true }) }
-    
     /// Returns another sequence that decodes each event's data as the provided type using the provided decoder.
     ///
     /// Use this method if the event's `data` field is JSON.
@@ -77,21 +76,20 @@ extension AsyncSequence where Element == ArraySlice<UInt8>, Self: Sendable {
     ///   - dataType: The type to decode the JSON data into.
     ///   - decoder: The JSON decoder to use.
     /// - Returns: A sequence that provides the events with the decoded JSON data.
-    @available(*, deprecated, renamed: "asDecodedServerSentEventsWithJSONData(of:decoder:while:)")
-    @_disfavoredOverload public func asDecodedServerSentEventsWithJSONData<JSONDataType: Decodable>(
+    @available(*, deprecated, renamed: "asDecodedServerSentEventsWithJSONData(of:decoder:while:)") @_disfavoredOverload
+    public func asDecodedServerSentEventsWithJSONData<JSONDataType: Decodable>(
         of dataType: JSONDataType.Type = JSONDataType.self,
         decoder: JSONDecoder = .init()
     ) -> AsyncThrowingMapSequence<
         ServerSentEventsDeserializationSequence<ServerSentEventsLineDeserializationSequence<Self>>,
         ServerSentEventWithJSONData<JSONDataType>
-    > {
-        asDecodedServerSentEventsWithJSONData(of: dataType, decoder: decoder, while: { _ in true })
-    }
+    > { asDecodedServerSentEventsWithJSONData(of: dataType, decoder: decoder, while: { _ in true }) }
 }
 
 extension ServerSentEventsDeserializationSequence {
     /// Creates a new sequence.
     /// - Parameter upstream: The upstream sequence of arbitrary byte chunks.
-    @available(*, deprecated, renamed: "init(upstream:while:)")
-    @_disfavoredOverload public init(upstream: Upstream) { self.init(upstream: upstream, while: { _ in true }) }
+    @available(*, deprecated, renamed: "init(upstream:while:)") @_disfavoredOverload public init(upstream: Upstream) {
+        self.init(upstream: upstream, while: { _ in true })
+    }
 }

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -28,9 +28,9 @@ where Upstream.Element == ArraySlice<UInt8> {
     /// The upstream sequence.
     private let upstream: Upstream
 
-    /// A closure that determines whether the given byte sequence is the terminating byte sequence defined by the API.
+    /// A closure that determines whether the given byte chunk should be forwarded to the consumer.
     /// - Parameter: A byte chunk.
-    /// - Returns: `True` until the terminating byte sequence is received.
+    /// - Returns: `true` if the byte chunk should be forwarded, `false` if this byte chunk is the terminating sequence.
     private let predicate: @Sendable (ArraySlice<UInt8>) -> Bool
 
     /// Creates a new sequence.

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -58,7 +58,7 @@ extension ServerSentEventsDeserializationSequence: AsyncSequence {
         /// The state machine of the iterator.
         var stateMachine: StateMachine
 
-        /// A closure that determines whether the given byte sequence is the terminating byte sequence defined by the API.
+        /// A closure that determines whether the given byte chunk should be forwarded to the consumer.
         /// - Parameter: A byte chunk.
         /// - Returns: `True` until the terminating byte sequence is received.
         let predicate: (ArraySlice<UInt8>) -> Bool

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -100,10 +100,11 @@ extension AsyncSequence where Element == ArraySlice<UInt8>, Self: Sendable {
     /// Use this method if the event's `data` field is not JSON, or if you don't want to parse it using `asDecodedServerSentEventsWithJSONData`.
     /// - Parameter: A closure that determines whether the given byte chunk should be forwarded to the consumer.
     /// - Returns: A sequence that provides the events.
-    public func asDecodedServerSentEvents(while predicate: @escaping @Sendable (ArraySlice<UInt8>) -> Bool = { _ in true }) -> ServerSentEventsDeserializationSequence<
-        ServerSentEventsLineDeserializationSequence<Self>
-    > { .init(upstream: ServerSentEventsLineDeserializationSequence(upstream: self), while: predicate) }
-    
+    public func asDecodedServerSentEvents(
+        while predicate: @escaping @Sendable (ArraySlice<UInt8>) -> Bool = { _ in true }
+    ) -> ServerSentEventsDeserializationSequence<ServerSentEventsLineDeserializationSequence<Self>> {
+        .init(upstream: ServerSentEventsLineDeserializationSequence(upstream: self), while: predicate)
+    }
     /// Returns another sequence that decodes each event's data as the provided type using the provided decoder.
     ///
     /// Use this method if the event's `data` field is JSON.
@@ -188,7 +189,6 @@ extension ServerSentEventsDeserializationSequence.Iterator {
                     // Dispatch the accumulated event.
                     // If the last character of data is a newline, strip it.
                     if event.data?.hasSuffix("\n") ?? false { event.data?.removeLast() }
-                    
                     if let data = event.data, !predicate(ArraySlice(data.utf8)) {
                         state = .finished
                         return .returnNil

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -58,11 +58,6 @@ extension ServerSentEventsDeserializationSequence: AsyncSequence {
         /// The state machine of the iterator.
         var stateMachine: StateMachine
 
-        /// A closure that determines whether the given byte chunk should be forwarded to the consumer.
-        /// - Parameter: A byte chunk.
-        /// - Returns: `true` if the byte chunk should be forwarded, `false` if this byte chunk is the terminating sequence.
-        let predicate: (ArraySlice<UInt8>) -> Bool
-
         /// Creates a new sequence.
         /// - Parameters:
         ///     - upstream: The upstream sequence of arbitrary byte chunks.
@@ -70,7 +65,6 @@ extension ServerSentEventsDeserializationSequence: AsyncSequence {
         init(upstream: UpstreamIterator, while predicate: @escaping ((ArraySlice<UInt8>) -> Bool)) {
             self.upstream = upstream
             self.stateMachine = .init(while: predicate)
-            self.predicate = predicate 
         }
 
         /// Asynchronously advances to the next element and returns it, or ends the

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -104,7 +104,7 @@ extension AsyncSequence where Element == ArraySlice<UInt8>, Self: Sendable {
     /// Returns another sequence that decodes each event's data as the provided type using the provided decoder.
     ///
     /// Use this method if the event's `data` field is not JSON, or if you don't want to parse it using `asDecodedServerSentEventsWithJSONData`.
-    /// - Parameter: A closure that determines whether the given byte sequence is the terminating byte sequence defined by the API.
+    /// - Parameter: A closure that determines whether the given byte chunk should be forwarded to the consumer.
     /// - Returns: A sequence that provides the events.
     public func asDecodedServerSentEvents(while predicate: @escaping @Sendable (ArraySlice<UInt8>) -> Bool = { _ in true }) -> ServerSentEventsDeserializationSequence<
         ServerSentEventsLineDeserializationSequence<Self>

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -106,11 +106,6 @@ extension AsyncSequence where Element == ArraySlice<UInt8>, Self: Sendable {
         ServerSentEventsLineDeserializationSequence<Self>
     > { .init(upstream: ServerSentEventsLineDeserializationSequence(upstream: self), terminate: terminate) }
     
-    /// Convenience function for `asDecodedServerSentEvents` that directly receives the terminating byte sequence.
-    public func asDecodedServerSentEvents(terminatingSequence: ArraySlice<UInt8>) -> ServerSentEventsDeserializationSequence<
-        ServerSentEventsLineDeserializationSequence<Self>
-    > { asDecodedServerSentEvents(terminate: { incomingSequence in return incomingSequence == terminatingSequence }) }
-
     /// Returns another sequence that decodes each event's data as the provided type using the provided decoder.
     ///
     /// Use this method if the event's `data` field is JSON.
@@ -138,19 +133,6 @@ extension AsyncSequence where Element == ArraySlice<UInt8>, Self: Sendable {
                     retry: event.retry
                 )
             }
-    }
-
-    public func asDecodedServerSentEventsWithJSONData<JSONDataType: Decodable>(
-        of dataType: JSONDataType.Type = JSONDataType.self,
-        decoder: JSONDecoder = .init(),
-        terminatingData: ArraySlice<UInt8>
-    ) -> AsyncThrowingMapSequence<
-        ServerSentEventsDeserializationSequence<ServerSentEventsLineDeserializationSequence<Self>>,
-        ServerSentEventWithJSONData<JSONDataType>
-    > {
-        asDecodedServerSentEventsWithJSONData(of: dataType, decoder: decoder) { incomingData in
-            terminatingData == incomingData
-        }
     }
 }
 

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -36,7 +36,7 @@ where Upstream.Element == ArraySlice<UInt8> {
     /// Creates a new sequence.
     /// - Parameters:
     ///     - upstream: The upstream sequence of arbitrary byte chunks.
-    ///     - while: A closure that determines whether the given byte chunk should be forwarded to the consumer.
+    ///     - predicate: A closure that determines whether the given byte chunk should be forwarded to the consumer.
     public init(upstream: Upstream, while predicate: @escaping @Sendable (ArraySlice<UInt8>) -> Bool) {
         self.upstream = upstream
         self.predicate = predicate

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -166,7 +166,8 @@ extension ServerSentEventsDeserializationSequence.Iterator {
         /// Creates a new state machine.
         init(while predicate: @escaping (ArraySlice<UInt8>) -> Bool) {
             self.state = .accumulatingEvent(.init(), buffer: [])
-            self.predicate = predicate}
+            self.predicate = predicate
+        }
 
         /// An action returned by the `next` method.
         enum NextAction {

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -60,7 +60,7 @@ extension ServerSentEventsDeserializationSequence: AsyncSequence {
 
         /// A closure that determines whether the given byte chunk should be forwarded to the consumer.
         /// - Parameter: A byte chunk.
-        /// - Returns: `True` until the terminating byte sequence is received.
+        /// - Returns: `true` if the byte chunk should be forwarded, `false` if this byte chunk is the terminating sequence.
         let predicate: (ArraySlice<UInt8>) -> Bool
 
         init(upstream: any AsyncIteratorProtocol, while predicate: @escaping ((ArraySlice<UInt8>) -> Bool)) {

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -63,6 +63,10 @@ extension ServerSentEventsDeserializationSequence: AsyncSequence {
         /// - Returns: `true` if the byte chunk should be forwarded, `false` if this byte chunk is the terminating sequence.
         let predicate: (ArraySlice<UInt8>) -> Bool
 
+        /// Creates a new sequence.
+        /// - Parameters:
+        ///     - upstream: The upstream sequence of arbitrary byte chunks.
+        ///     - while: A closure that determines whether the given byte chunk should be forwarded to the consumer.
         init(upstream: UpstreamIterator, while predicate: @escaping ((ArraySlice<UInt8>) -> Bool)) {
             self.upstream = upstream
             self.stateMachine = .init(while: predicate)

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -199,14 +199,14 @@ extension ServerSentEventsDeserializationSequence.Iterator {
                 buffer.removeFirst()
                 if line.isEmpty {
                     // Dispatch the accumulated event.
-                    state = .accumulatingEvent(.init(), buffer: buffer)
                     // If the last character of data is a newline, strip it.
                     if event.data?.hasSuffix("\n") ?? false { event.data?.removeLast() }
-
-                    if let data = event.data {
-                        if !predicate(ArraySlice(Data(data.utf8))) {
-                            return .returnNil
-                        }
+                    
+                    state = .accumulatingEvent(.init(), buffer: buffer)
+                    
+                    if let data = event.data, !predicate(ArraySlice(data.utf8)) {
+                        state = .finished
+                        return .returnNil
                     }
                     return .emitEvent(event)
                 }

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -61,7 +61,7 @@ extension ServerSentEventsDeserializationSequence: AsyncSequence {
         /// Creates a new sequence.
         /// - Parameters:
         ///     - upstream: The upstream sequence of arbitrary byte chunks.
-        ///     - while: A closure that determines whether the given byte chunk should be forwarded to the consumer.
+        ///     - predicate: A closure that determines whether the given byte chunk should be forwarded to the consumer.
         init(upstream: UpstreamIterator, while predicate: @escaping ((ArraySlice<UInt8>) -> Bool)) {
             self.upstream = upstream
             self.stateMachine = .init(while: predicate)
@@ -110,7 +110,7 @@ extension AsyncSequence where Element == ArraySlice<UInt8>, Self: Sendable {
     /// - Parameters:
     ///   - dataType: The type to decode the JSON data into.
     ///   - decoder: The JSON decoder to use.
-    ///   - while: A closure that determines whether the given byte sequence is the terminating byte sequence defined by the API.
+    ///   - predicate: A closure that determines whether the given byte sequence is the terminating byte sequence defined by the API.
     /// - Returns: A sequence that provides the events with the decoded JSON data.
     public func asDecodedServerSentEventsWithJSONData<JSONDataType: Decodable>(
         of dataType: JSONDataType.Type = JSONDataType.self,

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -189,12 +189,11 @@ extension ServerSentEventsDeserializationSequence.Iterator {
                     // If the last character of data is a newline, strip it.
                     if event.data?.hasSuffix("\n") ?? false { event.data?.removeLast() }
                     
-                    state = .accumulatingEvent(.init(), buffer: buffer, predicate: predicate)
-                    
                     if let data = event.data, !predicate(ArraySlice(data.utf8)) {
                         state = .finished
                         return .returnNil
                     }
+                    state = .accumulatingEvent(.init(), buffer: buffer, predicate: predicate)
                     return .emitEvent(event)
                 }
                 if line.first! == ASCII.colon {

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -63,8 +63,8 @@ extension ServerSentEventsDeserializationSequence: AsyncSequence {
         /// - Returns: `true` if the byte chunk should be forwarded, `false` if this byte chunk is the terminating sequence.
         let predicate: (ArraySlice<UInt8>) -> Bool
 
-        init(upstream: any AsyncIteratorProtocol, while predicate: @escaping ((ArraySlice<UInt8>) -> Bool)) {
-            self.upstream = upstream as! UpstreamIterator
+        init(upstream: UpstreamIterator, while predicate: @escaping ((ArraySlice<UInt8>) -> Bool)) {
+            self.upstream = upstream
             self.stateMachine = .init(while: predicate)
             self.predicate = predicate 
         }

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -36,7 +36,7 @@ where Upstream.Element == ArraySlice<UInt8> {
     /// Creates a new sequence.
     /// - Parameters:
     ///     - upstream: The upstream sequence of arbitrary byte chunks.
-    ///     - while: A closure that determines whether the given byte sequence is the terminating byte sequence defined by the API.
+    ///     - while: A closure that determines whether the given byte chunk should be forwarded to the consumer.
     public init(upstream: Upstream, while predicate: @escaping @Sendable (ArraySlice<UInt8>) -> Bool) {
         self.upstream = upstream
         self.predicate = predicate

--- a/Tests/OpenAPIRuntimeTests/EventStreams/Test_ServerSentEventsDecoding.swift
+++ b/Tests/OpenAPIRuntimeTests/EventStreams/Test_ServerSentEventsDecoding.swift
@@ -16,7 +16,7 @@ import XCTest
 import Foundation
 
 final class Test_ServerSentEventsDecoding: Test_Runtime {
-    func _test(input: String, output: [ServerSentEvent], file: StaticString = #filePath, line: UInt = #line, while predicate: ((ArraySlice<UInt8>) -> Bool)? = nil, eventCountOffset: Int = 0)
+    func _test(input: String, output: [ServerSentEvent], file: StaticString = #filePath, line: UInt = #line, while predicate: (ArraySlice<UInt8>) -> Bool = { _ in true }, eventCountOffset: Int = 0)
         async throws
     {
         let sequence = asOneBytePerElementSequence(ArraySlice(input.utf8)).asDecodedServerSentEvents()
@@ -112,7 +112,7 @@ final class Test_ServerSentEventsDecoding: Test_Runtime {
         output: [ServerSentEventWithJSONData<JSONType>],
         file: StaticString = #filePath,
         line: UInt = #line,
-        while predicate: (@Sendable (ArraySlice<UInt8>) -> Bool)? = nil
+        while predicate: @escaping @Sendable (ArraySlice<UInt8>) -> Bool = { _ in true }
     ) async throws {
         let sequence = asOneBytePerElementSequence(ArraySlice(input.utf8))
             .asDecodedServerSentEventsWithJSONData(of: JSONType.self, while: predicate)

--- a/Tests/OpenAPIRuntimeTests/EventStreams/Test_ServerSentEventsDecoding.swift
+++ b/Tests/OpenAPIRuntimeTests/EventStreams/Test_ServerSentEventsDecoding.swift
@@ -16,9 +16,13 @@ import XCTest
 import Foundation
 
 final class Test_ServerSentEventsDecoding: Test_Runtime {
-    func _test(input: String, output: [ServerSentEvent], file: StaticString = #filePath, line: UInt = #line, while predicate: @escaping @Sendable (ArraySlice<UInt8>) -> Bool = { _ in true })
-        async throws
-    {
+    func _test(
+        input: String,
+        output: [ServerSentEvent],
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        while predicate: @escaping @Sendable (ArraySlice<UInt8>) -> Bool = { _ in true }
+    ) async throws {
         let sequence = asOneBytePerElementSequence(ArraySlice(input.utf8)).asDecodedServerSentEvents(while: predicate)
         let events = try await [ServerSentEvent](collecting: sequence)
         XCTAssertEqual(events.count, output.count, file: file, line: line)
@@ -97,12 +101,8 @@ final class Test_ServerSentEventsDecoding: Test_Runtime {
 
 
                 """#,
-            output: [
-                .init(data: "hello\nworld")
-            ],
-            while: { incomingData in
-                incomingData != ArraySlice<UInt8>(Data("[DONE]".utf8))
-            }
+            output: [.init(data: "hello\nworld")],
+            while: { incomingData in incomingData != ArraySlice<UInt8>(Data("[DONE]".utf8)) }
         )
     }
     func _testJSONData<JSONType: Decodable & Hashable & Sendable>(
@@ -162,16 +162,14 @@ final class Test_ServerSentEventsDecoding: Test_Runtime {
                 event: event3
                 id: 1
                 data: {"index":3}
-                
-                
+
+
                 """#,
             output: [
                 .init(event: "event1", data: TestEvent(index: 1), id: "1"),
                 .init(event: "event2", data: TestEvent(index: 2), id: "2"),
             ],
-            while: { incomingData in
-                incomingData != ArraySlice<UInt8>(Data("[DONE]".utf8))
-            }
+            while: { incomingData in incomingData != ArraySlice<UInt8>(Data("[DONE]".utf8)) }
         )
     }
 }


### PR DESCRIPTION
### Motivation

As discussed in https://github.com/apple/swift-openapi-generator/issues/622, some APIs, e.g., ChatGPT or Claude, may return a non-JSON byte sequence to terminate a stream of events.
If not handled with a workaround (see below)such non-JSON terminating byte sequences cause a decoding error.

### Modifications

This PR adds the ability to customise the terminating byte sequence by providing a closure to `asDecodedServerSentEvents()` as well as `asDecodedServerSentEventsWithJSONData()` that can match incoming data for the terminating byte sequence before it is decoded into JSON, for instance.

### Result

Instead of having to decode and re-encode incoming events to filter out the terminating byte sequence - as seen in https://github.com/apple/swift-openapi-generator/issues/622#issuecomment-2346391088 - terminating byte sequences can now be cleanly caught by either providing a closure or providing the terminating byte sequence directly when calling `asDecodedServerSentEvents()` and `asDecodedServerSentEventsWithJSONData()`.

### Test Plan

This PR includes unit tests that test the new function parameters as part of the existing tests for `asDecodedServerSentEvents()` as well as `asDecodedServerSentEventsWithJSONData()`.
