### PR TITLE
ci: Migrate to GitHub Actions and reusable workflows, part one

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,43 @@
+name: PR
+
+on:
+    pull_request:
+      types: [opened, reopened, synchronize]
+
+jobs:
+    soundness:
+        name: Soundness
+        uses: apple/swift-nio/.github/workflows/soundness.yml@main
+        with:
+            api_breakage_check_enabled: true
+            broken_symlink_check_enabled: true
+            docs_check_enabled: true
+            format_check_enabled: true
+            license_header_check_enabled: true
+            license_header_check_project_name: "SwiftOpenAPIGenerator"
+            shell_check_enabled: true
+            unacceptable_language_check_enabled: true
+
+    unit-tests:
+        name: Unit tests
+        uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
+        with:
+            linux_5_8_enabled: false
+            linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_nightly_main_enabled: false
+
+    integration-test:
+        name: Integration test
+        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+        with:
+            name: "Integration test"
+            matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && ./scripts/run-integration-test.sh"
+            matrix_linux_5_8_enabled: false
+            matrix_linux_nightly_main_enabled: false
+
+    swift-6-language-mode:
+        name: Swift 6 Language Mode
+        uses: apple/swift-nio/.github/workflows/swift_6_language_mode.yml@main
+        if: false  # Disabled for now.

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,14 +9,16 @@ jobs:
         name: Soundness
         uses: apple/swift-nio/.github/workflows/soundness.yml@main
         with:
-            api_breakage_check_enabled: true
-            broken_symlink_check_enabled: true
-            docs_check_enabled: true
-            format_check_enabled: true
-            license_header_check_enabled: true
+            # These are set to false to stage this in with the old CI.
+            # A follow-up PR will cut them over.
+            api_breakage_check_enabled: false
+            broken_symlink_check_enabled: false
+            docs_check_enabled: false
+            format_check_enabled: false
+            license_header_check_enabled: false
             license_header_check_project_name: "SwiftOpenAPIGenerator"
-            shell_check_enabled: true
-            unacceptable_language_check_enabled: true
+            shell_check_enabled: false
+            unacceptable_language_check_enabled: false
 
     unit-tests:
         name: Unit tests

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,32 @@
+name: Scheduled
+
+on:
+    schedule:
+        - cron: "0 8,20 * * *"
+
+jobs:
+    unit-tests:
+        name: Unit tests
+        uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
+        with:
+            linux_5_8_enabled: false
+            linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+
+    integration-test:
+        name: Integration test
+        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+        with:
+            name: "Integration test"
+            matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && ./scripts/run-integration-test.sh"
+            matrix_linux_5_8_enabled: false
+
+    example-packages:
+        name: Example packages
+        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+        with:
+            name: "Example packages"
+            matrix_linux_command: "./scripts/test-examples.sh"
+            matrix_linux_5_8_enabled: false

--- a/.licenseignore
+++ b/.licenseignore
@@ -1,0 +1,9 @@
+.gitignore
+.licenseignore
+.swiftformatignore
+.spi.yml
+.swift-format
+.github/
+**.md
+**.txt
+Package.swift

--- a/.swiftformatignore
+++ b/.swiftformatignore
@@ -1,0 +1,1 @@
+Package.swift

--- a/scripts/check-for-breaking-api-changes.sh
+++ b/scripts/check-for-breaking-api-changes.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
 ## This source file is part of the SwiftOpenAPIGenerator open source project

--- a/scripts/check-for-broken-symlinks.sh
+++ b/scripts/check-for-broken-symlinks.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
 ## This source file is part of the SwiftOpenAPIGenerator open source project

--- a/scripts/check-for-docc-warnings.sh
+++ b/scripts/check-for-docc-warnings.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
 ## This source file is part of the SwiftOpenAPIGenerator open source project

--- a/scripts/check-for-unacceptable-language.sh
+++ b/scripts/check-for-unacceptable-language.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
 ## This source file is part of the SwiftOpenAPIGenerator open source project

--- a/scripts/check-license-headers.sh
+++ b/scripts/check-license-headers.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
 ## This source file is part of the SwiftOpenAPIGenerator open source project
@@ -51,6 +51,8 @@ read -ra PATHS_TO_CHECK_FOR_LICENSE <<< "$( \
   ":(exclude)Package.swift" \
   ":(exclude)README.md" \
   ":(exclude)SECURITY.md" \
+  ":(exclude).licenseignore" \
+  ":(exclude).swiftformatignore" \
   ":(exclude)scripts/unacceptable-language.txt" \
   ":(exclude)docker/*" \
   ":(exclude)**/*.docc/*" \
@@ -64,7 +66,7 @@ for FILE_PATH in "${PATHS_TO_CHECK_FOR_LICENSE[@]}"; do
   case "${FILE_EXTENSION}" in
     swift) EXPECTED_FILE_HEADER=$(sed -e 's|@@|//|g' <<<"${EXPECTED_FILE_HEADER_TEMPLATE}") ;;
     yml) EXPECTED_FILE_HEADER=$(sed -e 's|@@|##|g' <<<"${EXPECTED_FILE_HEADER_TEMPLATE}") ;;
-    sh) EXPECTED_FILE_HEADER=$(cat <(echo '#!/usr/bin/env bash') <(sed -e 's|@@|##|g' <<<"${EXPECTED_FILE_HEADER_TEMPLATE}")) ;;
+    sh) EXPECTED_FILE_HEADER=$(cat <(echo '#!/bin/bash') <(sed -e 's|@@|##|g' <<<"${EXPECTED_FILE_HEADER_TEMPLATE}")) ;;
     *) fatal "Unsupported file extension for file (exclude or update this script): ${FILE_PATH}" ;;
   esac
   EXPECTED_FILE_HEADER_LINECOUNT=$(wc -l <<<"${EXPECTED_FILE_HEADER}")

--- a/scripts/generate-contributors-list.sh
+++ b/scripts/generate-contributors-list.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
 ## This source file is part of the SwiftOpenAPIGenerator open source project

--- a/scripts/run-integration-test.sh
+++ b/scripts/run-integration-test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
 ## This source file is part of the SwiftOpenAPIGenerator open source project
@@ -24,7 +24,7 @@ JQ_BIN=${JQ_BIN:-$(command -v jq)} || fatal "JQ_BIN unset and no jq on PATH"
 
 CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_ROOT="$(git -C "${CURRENT_SCRIPT_DIR}" rev-parse --show-toplevel)"
-TMP_DIR=$(mktemp -d "${PWD}/tmp.$(basename "$0").XXXXXXXXXX.noindex")
+TMP_DIR=$(/usr/bin/mktemp -d -p "${TMPDIR-/tmp}" "$(basename "$0").XXXXXXXXXX")
 
 PACKAGE_PATH=${PACKAGE_PATH:-${REPO_ROOT}}
 
@@ -43,6 +43,6 @@ swift package --package-path "${INTEGRATION_TEST_PACKAGE_PATH}" \
     edit "${PACKAGE_NAME}" --path "${PACKAGE_PATH}"
 
 log "Building integration test package: ${INTEGRATION_TEST_PACKAGE_PATH}"
-swift build --package-path "${INTEGRATION_TEST_PACKAGE_PATH}" -Xswiftc -strict-concurrency=complete
+swift build --package-path "${INTEGRATION_TEST_PACKAGE_PATH}"
 
 log "✅ Successfully built integration test package."

--- a/scripts/run-swift-format.sh
+++ b/scripts/run-swift-format.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
 ## This source file is part of the SwiftOpenAPIGenerator open source project

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
 ## This source file is part of the SwiftOpenAPIGenerator open source project


### PR DESCRIPTION
### Motivation

Following on from the migration in Swift OpenAPI Generator, we need to migrate this repo to GitHub Actions based CI and the reusable workflows that are currently in the NIO repo. 

### Modifications

In order to bootstrap the migration, we need to merge the workflows in, otherwise we won't get any PR feedback on them while we get them ready. As a practical matter, they are all passing locally (verified) by `act` but it would be nice to stage these in so we can keep a green CI while we migrate and decommission the old CI.

So this disables the soundness checks for now, so we can then use a follow up PR to do the cut over with testing in the PR.

### Result

Old CI still working, new CI should start running in some capacity.