### PR TITLE
ci: Remove examples pipeline from scheduled workflow

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -22,11 +22,3 @@ jobs:
             name: "Integration test"
             matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && ./scripts/run-integration-test.sh"
             matrix_linux_5_8_enabled: false
-
-    example-packages:
-        name: Example packages
-        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
-        with:
-            name: "Example packages"
-            matrix_linux_command: "./scripts/test-examples.sh"
-            matrix_linux_5_8_enabled: false


### PR DESCRIPTION
### Motivation

This was copied in from the generator repo but there aren't examples in this repo so the job is failing.

### Modifications

Remove this job from the scheduled workflow. 

### Result

Scheduled workflow should now pass fully. 

### Test Plan

None. 