### PR TITLE
[CI] Update to Swift 6 CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,24 +7,17 @@ on:
 jobs:
     soundness:
         name: Soundness
-        uses: apple/swift-nio/.github/workflows/soundness.yml@main
+        uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
         with:
-            api_breakage_check_enabled: true
-            broken_symlink_check_enabled: true
-            docs_check_enabled: true
-            format_check_enabled: true
-            license_header_check_enabled: true
             license_header_check_project_name: "SwiftOpenAPIGenerator"
-            shell_check_enabled: true
-            unacceptable_language_check_enabled: true
 
     unit-tests:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
-            linux_5_8_enabled: false
             linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
             linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
             linux_nightly_main_enabled: false
 
@@ -34,7 +27,6 @@ jobs:
         with:
             name: "Integration test"
             matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && ./scripts/run-integration-test.sh"
-            matrix_linux_5_8_enabled: false
             matrix_linux_nightly_main_enabled: false
 
     swift-6-language-mode:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,35 +1,35 @@
 name: PR
 
 on:
-    pull_request:
-      types: [opened, reopened, synchronize]
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
-    soundness:
-        name: Soundness
-        uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
-        with:
-            license_header_check_project_name: "SwiftOpenAPIGenerator"
+  soundness:
+    name: Soundness
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
+    with:
+      license_header_check_project_name: "SwiftOpenAPIGenerator"
 
-    unit-tests:
-        name: Unit tests
-        uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
-        with:
-            linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_nightly_main_enabled: false
+  unit-tests:
+    name: Unit tests
+    uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
+    with:
+      linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_nightly_main_enabled: false
 
-    integration-test:
-        name: Integration test
-        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
-        with:
-            name: "Integration test"
-            matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && ./scripts/run-integration-test.sh"
-            matrix_linux_nightly_main_enabled: false
+  integration-test:
+    name: Integration test
+    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    with:
+      name: "Integration test"
+      matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && ./scripts/run-integration-test.sh"
+      matrix_linux_nightly_main_enabled: false
 
-    swift-6-language-mode:
-        name: Swift 6 Language Mode
-        uses: apple/swift-nio/.github/workflows/swift_6_language_mode.yml@main
-        if: false  # Disabled for now.
+  swift-6-language-mode:
+    name: Swift 6 Language Mode
+    uses: apple/swift-nio/.github/workflows/swift_6_language_mode.yml@main
+    if: false  # Disabled for now.

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -9,9 +9,9 @@ jobs:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
-            linux_5_8_enabled: false
             linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
             linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
             linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
@@ -21,4 +21,3 @@ jobs:
         with:
             name: "Integration test"
             matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && ./scripts/run-integration-test.sh"
-            matrix_linux_5_8_enabled: false

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,23 +1,23 @@
 name: Scheduled
 
 on:
-    schedule:
-        - cron: "0 8,20 * * *"
+  schedule:
+    - cron: "0 8,20 * * *"
 
 jobs:
-    unit-tests:
-        name: Unit tests
-        uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
-        with:
-            linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+  unit-tests:
+    name: Unit tests
+    uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
+    with:
+      linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
-    integration-test:
-        name: Integration test
-        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
-        with:
-            name: "Integration test"
-            matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && ./scripts/run-integration-test.sh"
+  integration-test:
+    name: Integration test
+    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    with:
+      name: "Integration test"
+      matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && ./scripts/run-integration-test.sh"

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,5 +1,5 @@
 version: 1
 builder:
   configs:
-  - documentation_targets:
-    - OpenAPIRuntime
+    - documentation_targets:
+        - OpenAPIRuntime

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -29,8 +29,9 @@ where Upstream.Element == ArraySlice<UInt8> {
     private let upstream: Upstream
 
     /// A closure that determines whether the given byte chunk should be forwarded to the consumer.
-    /// - Parameter: A byte chunk.
-    /// - Returns: `true` if the byte chunk should be forwarded, `false` if this byte chunk is the terminating sequence.
+    ///
+    /// The closure should return `true` if the byte chunk should be forwarded and
+    /// `false` if this byte chunk is the terminating sequence.
     private let predicate: @Sendable (ArraySlice<UInt8>) -> Bool
 
     /// Creates a new sequence.
@@ -98,7 +99,7 @@ extension AsyncSequence where Element == ArraySlice<UInt8>, Self: Sendable {
     /// Returns another sequence that decodes each event's data as the provided type using the provided decoder.
     ///
     /// Use this method if the event's `data` field is not JSON, or if you don't want to parse it using `asDecodedServerSentEventsWithJSONData`.
-    /// - Parameter: A closure that determines whether the given byte chunk should be forwarded to the consumer.
+    /// - Parameter predicate: A closure that determines whether the given byte chunk should be forwarded to the consumer.
     /// - Returns: A sequence that provides the events.
     public func asDecodedServerSentEvents(
         while predicate: @escaping @Sendable (ArraySlice<UInt8>) -> Bool = { _ in true }


### PR DESCRIPTION
# Motivation

We just updated our CI matrix in NIO to only support 5.9, 5.10 and 6.

# Modification

This PR updates the trigger files in this repo. Since this repo was always 5.9+ this is easy.

# Result

Up to date CI