### PR TITLE
Fix up doc comments

### DIFF
--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -29,7 +29,6 @@ where Upstream.Element == ArraySlice<UInt8> {
     private let upstream: Upstream
 
     /// A closure that determines whether the given byte chunk should be forwarded to the consumer.
-    /// - Parameter: A byte chunk.
     /// - Returns: `true` if the byte chunk should be forwarded, `false` if this byte chunk is the terminating sequence.
     private let predicate: @Sendable (ArraySlice<UInt8>) -> Bool
 
@@ -98,7 +97,7 @@ extension AsyncSequence where Element == ArraySlice<UInt8>, Self: Sendable {
     /// Returns another sequence that decodes each event's data as the provided type using the provided decoder.
     ///
     /// Use this method if the event's `data` field is not JSON, or if you don't want to parse it using `asDecodedServerSentEventsWithJSONData`.
-    /// - Parameter: A closure that determines whether the given byte chunk should be forwarded to the consumer.
+    /// - Parameter predicate: A closure that determines whether the given byte chunk should be forwarded to the consumer.
     /// - Returns: A sequence that provides the events.
     public func asDecodedServerSentEvents(
         while predicate: @escaping @Sendable (ArraySlice<UInt8>) -> Bool = { _ in true }


### PR DESCRIPTION
### Motivation

Unblock https://github.com/apple/swift-openapi-runtime/pull/122#issuecomment-2415982172

### Modifications

Fixed up a doc comment.

### Result

No more warnings with Swift 6 compiler docc.

### Test Plan

Verified locally.
