### PR TITLE
Add Mac Catalyst support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let swiftSettings: [SwiftSetting] = [
 let package = Package(
     name: "swift-openapi-runtime",
     platforms: [
-        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .visionOS(.v1)
+        .macOS(.v10_15), .macCatalyst(.v13), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .visionOS(.v1)
     ],
     products: [
         .library(


### PR DESCRIPTION
### Motivation

Support the runtime in Mac Catalyst apps.

### Modifications

Add the platform requirement to Package.swift.

### Result

Builds correctly for Mac Catalyst now.

### Test Plan

Unit tests passed.
