### PR TITLE
Add error handling middleware

### DIFF
--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -14,7 +14,7 @@
 
 import HTTPTypes
 
-/// An opt-in error Handling middleware that converts an error to a HTTP response.
+/// An opt-in error handling middleware that converts an error to a HTTP response.
 ///
 /// Inclusion of  ``ErrorHandlingMiddleware`` should be accompanied by confirming errors to ``HTTPResponseConvertible``  protocol.
 /// Undocumented errors, i.e, errors not confriming to ``HTTPResponseConvertible`` are converted to a response with 500 status code.

--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -73,6 +73,7 @@ public protocol HTTPResponseConvertible {
     /// HTTP status to return in the response.
     var httpStatus: HTTPResponse.Status { get }
     /// Headers to return in the response.
+    ///
     /// This is optional as default values are provided in the extension.
     var httpHeaderFields: HTTPTypes.HTTPFields { get }
     /// (Optional) The body of the response to return

--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -76,7 +76,7 @@ public protocol HTTPResponseConvertible {
     ///
     /// This is optional as default values are provided in the extension.
     var httpHeaderFields: HTTPTypes.HTTPFields { get }
-    /// (Optional) The body of the response to return
+    /// The body of the HTTP response.
     var httpBody: OpenAPIRuntime.HTTPBody? { get }
 }
 

--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -16,7 +16,7 @@ import HTTPTypes
 
 /// An opt-in error handling middleware that converts an error to a HTTP response.
 ///
-/// Inclusion of  ``ErrorHandlingMiddleware`` should be accompanied by confirming errors to ``HTTPResponseConvertible``  protocol.
+/// Inclusion of  ``ErrorHandlingMiddleware`` should be accompanied by conforming errors to the ``HTTPResponseConvertible``  protocol.
 /// Undocumented errors, i.e, errors not confriming to ``HTTPResponseConvertible`` are converted to a response with 500 status code.
 ///
 /// Example usage

--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -72,7 +72,7 @@ public protocol HTTPResponseConvertible {
 
     /// HTTP status to return in the response.
     var httpStatus: HTTPResponse.Status { get }
-    /// Headers to return in the response.
+    /// The HTTP headers of the response.
     ///
     /// This is optional as default values are provided in the extension.
     var httpHeaderFields: HTTPTypes.HTTPFields { get }

--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -14,7 +14,7 @@
 
 import HTTPTypes
 
-/// An opt-in error handling middleware that converts an error to a HTTP response.
+/// An opt-in error handling middleware that converts an error to an HTTP response.
 ///
 /// Inclusion of  ``ErrorHandlingMiddleware`` should be accompanied by conforming errors to the ``HTTPResponseConvertible``  protocol.
 /// Errors not conforming to ``HTTPResponseConvertible`` are converted to a response with the 500 status code.

--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -19,7 +19,7 @@ import HTTPTypes
 /// Inclusion of  ``ErrorHandlingMiddleware`` should be accompanied by conforming errors to the ``HTTPResponseConvertible``  protocol.
 /// Errors not conforming to ``HTTPResponseConvertible`` are converted to a response with the 500 status code.
 ///
-/// Example usage
+/// ## Example usage
 /// 1. Create an error type that conforms to HTTPResponseConvertible protocol:
 ///
 /// ```swift

--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -20,6 +20,7 @@ import HTTPTypes
 /// Errors not conforming to ``HTTPResponseConvertible`` are converted to a response with the 500 status code.
 ///
 /// ## Example usage
+///
 /// 1. Create an error type that conforms to the ``HTTPResponseConvertible`` protocol:
 ///
 /// ```swift
@@ -35,28 +36,19 @@ import HTTPTypes
 /// }
 /// ```
 ///
-/// 2. Opt in to the ``ErrorHandlingMiddleware``  while registering the handler:
+/// 2. Opt into the ``ErrorHandlingMiddleware``  while registering the handler:
 ///
 /// ```swift
 /// let handler = RequestHandler()
 /// try handler.registerHandlers(on: transport, middlewares: [ErrorHandlingMiddleware()])
 /// ```
-/// - Note: The placement of ``ErrorHandlingMiddleware`` in the middleware chain is important.
-/// It should be determined based on the specific needs of each application.
-/// Consider the order of execution and dependencies between middlewares.
+/// - Note: The placement of ``ErrorHandlingMiddleware`` in the middleware chain is important. It should be determined based on the specific needs of each application. Consider the order of execution and dependencies between middlewares.
 public struct ErrorHandlingMiddleware: ServerMiddleware {
     
-    /// Creates an ErrorHandlingMiddleware.
+    /// Creates a new middleware.
     public init() {}
     
-    /// Intercepts an outgoing HTTP request and an incoming HTTP Response, and converts errors(if any) that confirms to ``HTTPResponseConvertible`` to an HTTP response.
-    /// - Parameters:
-    ///   - request: The HTTP request created during the operation.
-    ///   - body: The HTTP request body created during the operation.
-    ///   - metadata: Request metadata
-    ///   - operationID: The OpenAPI operation identifier.
-    ///   - next: A closure that calls the next middleware, or the transport.
-    /// - Returns: An HTTPResponse and an optional HTTPBody.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func intercept(
         _ request: HTTPTypes.HTTPRequest,
         body: OpenAPIRuntime.HTTPBody?,
@@ -78,21 +70,29 @@ public struct ErrorHandlingMiddleware: ServerMiddleware {
     }
 }
 
-/// A protocol used by ``ErrorHandlingMiddleware`` to map an error to an ``HTTPResponse`` and ``HTTPBody``.
-/// Adopters who wish to convert their application error to an `HTTPResponse` and ``HTTPBody`` should conform the error type to this protocol.
+/// A value that can be converted to an HTTP response and body.
+///
+/// Conform your error type to this protocol to convert it to an `HTTPResponse` and ``HTTPBody``.
+///
+/// Used by ``ErrorHandlingMiddleware``.
 public protocol HTTPResponseConvertible {
 
     /// An HTTP status to return in the response.
     var httpStatus: HTTPResponse.Status { get }
-    /// The HTTP headers of the response.
+
+    /// The HTTP header fields of the response.
     /// This is optional as default values are provided in the extension.
     var httpHeaderFields: HTTPTypes.HTTPFields { get }
+
     /// The body of the HTTP response.
     var httpBody: OpenAPIRuntime.HTTPBody? { get }
 }
 
-/// Extension to HTTPResponseConvertible to provide default values for certain fields.
 extension HTTPResponseConvertible {
+
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var httpHeaderFields: HTTPTypes.HTTPFields { [:] }
+
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var httpBody: OpenAPIRuntime.HTTPBody? { nil }
 }

--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -80,8 +80,8 @@ public protocol HTTPResponseConvertible {
     var httpBody: OpenAPIRuntime.HTTPBody? { get }
 }
 
-/// Extension to HTTPResponseConvertible to provide default values for certian fields.
-public extension HTTPResponseConvertible {
-    var httpHeaderFields: HTTPTypes.HTTPFields { [:] }
-    var httpBody: OpenAPIRuntime.HTTPBody? { nil }
+/// Extension to HTTPResponseConvertible to provide default values for certain fields.
+extension HTTPResponseConvertible {
+    public var httpHeaderFields: HTTPTypes.HTTPFields { [:] }
+    public var httpBody: OpenAPIRuntime.HTTPBody? { nil }
 }

--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HTTPTypes
+
+/// Error Handling middleware that converts an error to a HTTP response
+///
+/// This is an opt-in middleware that adopters may choose to include to convert application errors
+/// to a HTTP Response
+///
+/// Inclusion of this ErrorHandling Middleware should be accompanied by confirming errors to
+/// HTTPResponseConvertible protocol. Only errors  confirming to HTTPResponseConvertible are converted to a HTTP response. Other errors are re-thrown from this middleware.
+///
+/// Example usage
+/// 1. Create an error type that conforms to HTTPResponseConvertible protocol
+/// ```swift
+/// extension MyAppError: HTTPResponseConvertible {
+///    var httpStatus: HTTPResponse.Status {
+///    switch self {
+///        case .invalidInputFormat:
+///            .badRequest
+///        case .authorizationError:
+///            .forbidden
+///        }
+///    }
+/// }
+/// ```
+///
+/// 2. Opt in to the error middleware while registering the handler
+///
+/// ```swift
+/// let handler = try await RequestHandler()
+/// try handler.registerHandlers(on: transport, middlewares: [ErrorHandlingMiddleware()])
+///
+
+public struct ErrorHandlingMiddleware: ServerMiddleware {
+    public func intercept(_ request: HTTPTypes.HTTPRequest,
+                          body: OpenAPIRuntime.HTTPBody?,
+                          metadata: OpenAPIRuntime.ServerRequestMetadata,
+                          operationID: String,
+                          next: @Sendable (HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?)) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
+        do {
+            return try await next(request, body, metadata)
+        } catch let error as ServerError {
+            if let appError = error.underlyingError as? (any HTTPResponseConvertible) {
+                return (HTTPResponse(status: appError.httpStatus, headerFields: appError.httpHeaderFields),
+                appError.httpBody)
+            } else {
+                throw error
+            }
+        }
+    }
+}
+
+/// Protocol used by ErrorHandling middleware to map an error to a HTTPResponse
+///
+/// Adopters who wish to convert their application error to a HTTPResponse
+/// should confirm their error(s) to this protocol
+
+public protocol HTTPResponseConvertible {
+    /// HTTP status to return in the response
+    var httpStatus: HTTPResponse.Status { get }
+    
+    /// (Optional) Headers to return in the response
+    var httpHeaderFields: HTTPTypes.HTTPFields { get }
+    
+    /// (Optional) The body of the response to return
+    var httpBody: OpenAPIRuntime.HTTPBody? { get }
+}
+
+/// Extension to HTTPResponseConvertible to provide default values for certian fields
+public extension HTTPResponseConvertible {
+    var httpHeaderFields: HTTPTypes.HTTPFields { [:] }
+    var httpBody: OpenAPIRuntime.HTTPBody? { nil }
+}

--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -25,7 +25,7 @@ import HTTPTypes
 /// ```swift
 /// extension MyAppError: HTTPResponseConvertible {
 ///    var httpStatus: HTTPResponse.Status {
-///    switch self {
+///        switch self {
 ///        case .invalidInputFormat:
 ///            .badRequest
 ///        case .authorizationError:
@@ -38,13 +38,25 @@ import HTTPTypes
 /// 2. Opt in to the ``ErrorHandlingMiddleware``  while registering the handler:
 ///
 /// ```swift
-/// let handler = try await RequestHandler()
+/// let handler = RequestHandler()
 /// try handler.registerHandlers(on: transport, middlewares: [ErrorHandlingMiddleware()])
 /// ```
 /// - Note: The placement of ``ErrorHandlingMiddleware`` in the middleware chain is important.
 /// It should be determined based on the specific needs of each application.
 /// Consider the order of execution and dependencies between middlewares.
 public struct ErrorHandlingMiddleware: ServerMiddleware {
+    
+    /// Creates an ErrorHandlingMiddleware.
+    public init() {}
+    
+    /// Intercepts an outgoing HTTP request and an incoming HTTP Response, and converts errors(if any) that confirms to ``HTTPResponseConvertible`` to an HTTP response.
+    /// - Parameters:
+    ///   - request: The HTTP request created during the operation.
+    ///   - body: The HTTP request body created during the operation.
+    ///   - metadata: Request metadata
+    ///   - operationID: The OpenAPI operation identifier.
+    ///   - next: A closure that calls the next middleware, or the transport.
+    /// - Returns: An HTTPResponse and an optional HTTPBody.
     public func intercept(
         _ request: HTTPTypes.HTTPRequest,
         body: OpenAPIRuntime.HTTPBody?,
@@ -66,14 +78,13 @@ public struct ErrorHandlingMiddleware: ServerMiddleware {
     }
 }
 
-/// Protocol used by ErrorHandling middleware to map an error to a HTTPResponse.
-/// Adopters who wish to convert their application error to a HTTPResponse should confirm their error(s) to this protocol.
+/// A protocol used by ``ErrorHandlingMiddleware`` to map an error to an ``HTTPResponse`` and ``HTTPBody``.
+/// Adopters who wish to convert their application error to an `HTTPResponse` and ``HTTPBody`` should conform the error type to this protocol.
 public protocol HTTPResponseConvertible {
 
-    /// HTTP status to return in the response.
+    /// An HTTP status to return in the response.
     var httpStatus: HTTPResponse.Status { get }
     /// The HTTP headers of the response.
-    ///
     /// This is optional as default values are provided in the extension.
     var httpHeaderFields: HTTPTypes.HTTPFields { get }
     /// The body of the HTTP response.

--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -20,7 +20,7 @@ import HTTPTypes
 /// Errors not conforming to ``HTTPResponseConvertible`` are converted to a response with the 500 status code.
 ///
 /// ## Example usage
-/// 1. Create an error type that conforms to HTTPResponseConvertible protocol:
+/// 1. Create an error type that conforms to the ``HTTPResponseConvertible`` protocol:
 ///
 /// ```swift
 /// extension MyAppError: HTTPResponseConvertible {

--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -44,10 +44,8 @@ import HTTPTypes
 /// ```
 /// - Note: The placement of ``ErrorHandlingMiddleware`` in the middleware chain is important. It should be determined based on the specific needs of each application. Consider the order of execution and dependencies between middlewares.
 public struct ErrorHandlingMiddleware: ServerMiddleware {
-    
     /// Creates a new middleware.
     public init() {}
-    
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func intercept(
         _ request: HTTPTypes.HTTPRequest,
@@ -58,7 +56,9 @@ public struct ErrorHandlingMiddleware: ServerMiddleware {
             async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?)
     ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
         do { return try await next(request, body, metadata) } catch {
-            if let serverError = error as? ServerError, let appError = serverError.underlyingError as? (any HTTPResponseConvertible) {
+            if let serverError = error as? ServerError,
+                let appError = serverError.underlyingError as? (any HTTPResponseConvertible)
+            {
                 return (
                     HTTPResponse(status: appError.httpStatus, headerFields: appError.httpHeaderFields),
                     appError.httpBody

--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -17,7 +17,7 @@ import HTTPTypes
 /// An opt-in error handling middleware that converts an error to a HTTP response.
 ///
 /// Inclusion of  ``ErrorHandlingMiddleware`` should be accompanied by conforming errors to the ``HTTPResponseConvertible``  protocol.
-/// Undocumented errors, i.e, errors not confriming to ``HTTPResponseConvertible`` are converted to a response with 500 status code.
+/// Errors not conforming to ``HTTPResponseConvertible`` are converted to a response with the 500 status code.
 ///
 /// Example usage
 /// 1. Create an error type that conforms to HTTPResponseConvertible protocol:

--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -57,8 +57,8 @@ public struct ErrorHandlingMiddleware: ServerMiddleware {
         next: @Sendable (HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata)
             async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?)
     ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
-        do { return try await next(request, body, metadata) } catch let error as ServerError {
-            if let appError = error.underlyingError as? (any HTTPResponseConvertible) {
+        do { return try await next(request, body, metadata) } catch {
+            if let serverError = error as? ServerError, let appError = serverError.underlyingError as? (any HTTPResponseConvertible) {
                 return (
                     HTTPResponse(status: appError.httpStatus, headerFields: appError.httpHeaderFields),
                     appError.httpBody

--- a/Tests/OpenAPIRuntimeTests/Interface/Test_ErrorHandlingMiddleware.swift
+++ b/Tests/OpenAPIRuntimeTests/Interface/Test_ErrorHandlingMiddleware.swift
@@ -1,0 +1,144 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HTTPTypes
+
+import XCTest
+@_spi(Generated) @testable import OpenAPIRuntime
+
+
+final class Test_ErrorHandlingMiddlewareTests: XCTestCase {
+    static let mockRequest: HTTPRequest = .init(soar_path: "http://abc.com", method: .get)
+    static let mockBody: HTTPBody = HTTPBody("hello")
+    static let errorHandlingMiddleware = ErrorHandlingMiddleware()
+
+    func testSuccessfulRequest() async throws {
+        let response = try await Test_ErrorHandlingMiddlewareTests.errorHandlingMiddleware.intercept(Test_ErrorHandlingMiddlewareTests.mockRequest,
+                                                                                                     body: Test_ErrorHandlingMiddlewareTests.mockBody,
+                                                                                                     metadata: .init(), operationID: "testop",
+                                                                                                     next: getNextMiddleware(failurePhase: .never))
+        XCTAssertEqual(response.0.status, .ok)
+    }
+    
+    func testError_confirmingToProtocol_convertedToResponse() async throws {
+        let (response, responseBody) = try await Test_ErrorHandlingMiddlewareTests.errorHandlingMiddleware.intercept(Test_ErrorHandlingMiddlewareTests.mockRequest,
+                                                                                                     body: Test_ErrorHandlingMiddlewareTests.mockBody,
+                                                                                                     metadata: .init(), operationID: "testop",
+                                                                                                     next: getNextMiddleware(failurePhase: .convertibleError))
+        XCTAssertEqual(response.status, .badGateway)
+        XCTAssertEqual(response.headerFields, [.contentType: "application/json"])
+        XCTAssertEqual(responseBody, TEST_HTTP_BODY)
+    }
+
+    
+    func testError_confirmingToProtocolWithoutAllValues_convertedToResponse() async throws {
+        let (response, responseBody) = try await Test_ErrorHandlingMiddlewareTests.errorHandlingMiddleware.intercept(Test_ErrorHandlingMiddlewareTests.mockRequest,
+                                                                                                     body: Test_ErrorHandlingMiddlewareTests.mockBody,
+                                                                                                     metadata: .init(), operationID: "testop",
+                                                                                                                     next: getNextMiddleware(failurePhase: .partialConvertibleError))
+        XCTAssertEqual(response.status, .badRequest)
+        XCTAssertEqual(response.headerFields, [:])
+        XCTAssertEqual(responseBody, nil)
+    }
+    
+    func testError_notConfirmingToProtocol_throws() async throws {
+
+        do {
+            _ = try await Test_ErrorHandlingMiddlewareTests.errorHandlingMiddleware.intercept(Test_ErrorHandlingMiddlewareTests.mockRequest,
+                                                                                                                body: Test_ErrorHandlingMiddlewareTests.mockBody,
+                                                                                                                metadata: .init(), operationID: "testop",
+                                                                                          next: getNextMiddleware(failurePhase: .nonConvertibleError))
+            XCTFail("Expected error to be thrown")
+        } catch {
+            let error = error as? ServerError
+            XCTAssertTrue(error?.underlyingError is NonConvertibleError)
+        }
+    }
+        
+    private func getNextMiddleware(failurePhase: MockErrorMiddleware_Next.FailurePhase) -> @Sendable (HTTPTypes.HTTPRequest,
+                                                                                                     OpenAPIRuntime.HTTPBody?,
+                                                                                                     OpenAPIRuntime.ServerRequestMetadata) async throws ->
+                                                                            (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
+        
+        let mockNext: @Sendable (HTTPTypes.HTTPRequest,
+                                 OpenAPIRuntime.HTTPBody?,
+                                 OpenAPIRuntime.ServerRequestMetadata) async throws ->
+        (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) =
+        { request, body, metadata in
+            try await MockErrorMiddleware_Next(failurePhase: failurePhase).intercept(request,
+                                                                                    body: body,
+                                                                                    metadata: metadata,
+                                                                                    operationID: "testop",
+                                                                                    next: { _,_,_  in (HTTPResponse.init(status: .ok), nil) })
+        }
+        return mockNext
+    }
+}
+
+struct MockErrorMiddleware_Next: ServerMiddleware {
+    enum FailurePhase {
+        case never
+        case convertibleError
+        case nonConvertibleError
+        case partialConvertibleError
+    }
+    var failurePhase: FailurePhase = .never
+
+    @Sendable
+    func intercept(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        metadata: ServerRequestMetadata,
+        operationID: String,
+        next: (HTTPRequest, HTTPBody?, ServerRequestMetadata) async throws -> (HTTPResponse, HTTPBody?)
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        var error: (any Error)?
+        switch failurePhase {
+        case .never:
+            break
+        case .convertibleError:
+            error = ConvertibleError()
+        case .nonConvertibleError:
+            error = NonConvertibleError()
+        case .partialConvertibleError:
+            error = PartialConvertibleError()
+        }
+        
+        if let underlyingError = error {
+            throw ServerError(operationID: operationID,
+                              request: request,
+                              requestBody: body,
+                              requestMetadata: metadata,
+                              causeDescription: "",
+                              underlyingError: underlyingError)
+        }
+        
+        let (response, responseBody) = try await next(request, body, metadata)
+        return (response, responseBody)
+    }
+}
+
+struct ConvertibleError: Error, HTTPResponseConvertible {
+    var httpStatus: HTTPTypes.HTTPResponse.Status = HTTPResponse.Status.badGateway
+    var httpHeaderFields: HTTPFields = [.contentType: "application/json"]
+    var httpBody: OpenAPIRuntime.HTTPBody? = TEST_HTTP_BODY
+}
+
+struct PartialConvertibleError: Error, HTTPResponseConvertible {
+    var httpStatus: HTTPTypes.HTTPResponse.Status = HTTPResponse.Status.badRequest
+}
+
+struct NonConvertibleError: Error {}
+
+let TEST_HTTP_BODY = HTTPBody(try! JSONEncoder().encode(["error"," test error"]))

--- a/Tests/OpenAPIRuntimeTests/Interface/Test_ErrorHandlingMiddleware.swift
+++ b/Tests/OpenAPIRuntimeTests/Interface/Test_ErrorHandlingMiddleware.swift
@@ -43,7 +43,7 @@ final class Test_ErrorHandlingMiddlewareTests: XCTestCase {
         )
         XCTAssertEqual(response.status, .badGateway)
         XCTAssertEqual(response.headerFields, [.contentType: "application/json"])
-        XCTAssertEqual(responseBody, TEST_HTTP_BODY)
+        XCTAssertEqual(responseBody, testHTTPBody)
     }
 
     func testError_conformingToProtocolWithoutAllValues_convertedToResponse() async throws {
@@ -132,7 +132,7 @@ struct MockErrorMiddleware_Next: ServerMiddleware {
 struct ConvertibleError: Error, HTTPResponseConvertible {
     var httpStatus: HTTPTypes.HTTPResponse.Status = HTTPResponse.Status.badGateway
     var httpHeaderFields: HTTPFields = [.contentType: "application/json"]
-    var httpBody: OpenAPIRuntime.HTTPBody? = TEST_HTTP_BODY
+    var httpBody: OpenAPIRuntime.HTTPBody? = testHTTPBody
 }
 
 struct PartialConvertibleError: Error, HTTPResponseConvertible {

--- a/Tests/OpenAPIRuntimeTests/Interface/Test_ErrorHandlingMiddleware.swift
+++ b/Tests/OpenAPIRuntimeTests/Interface/Test_ErrorHandlingMiddleware.swift
@@ -32,7 +32,8 @@ final class Test_ErrorHandlingMiddlewareTests: XCTestCase {
         )
         XCTAssertEqual(response.0.status, .ok)
     }
-    func testError_confirmingToProtocol_convertedToResponse() async throws {
+
+    func testError_conformingToProtocol_convertedToResponse() async throws {
         let (response, responseBody) = try await Test_ErrorHandlingMiddlewareTests.errorHandlingMiddleware.intercept(
             Test_ErrorHandlingMiddlewareTests.mockRequest,
             body: Test_ErrorHandlingMiddlewareTests.mockBody,
@@ -45,7 +46,7 @@ final class Test_ErrorHandlingMiddlewareTests: XCTestCase {
         XCTAssertEqual(responseBody, TEST_HTTP_BODY)
     }
 
-    func testError_confirmingToProtocolWithoutAllValues_convertedToResponse() async throws {
+    func testError_conformingToProtocolWithoutAllValues_convertedToResponse() async throws {
         let (response, responseBody) = try await Test_ErrorHandlingMiddlewareTests.errorHandlingMiddleware.intercept(
             Test_ErrorHandlingMiddlewareTests.mockRequest,
             body: Test_ErrorHandlingMiddlewareTests.mockBody,
@@ -57,7 +58,8 @@ final class Test_ErrorHandlingMiddlewareTests: XCTestCase {
         XCTAssertEqual(response.headerFields, [:])
         XCTAssertEqual(responseBody, nil)
     }
-    func testError_notConfirmingToProtocol_returns500() async throws {
+
+    func testError_notConformingToProtocol_returns500() async throws {
         let (response, responseBody) = try await Test_ErrorHandlingMiddlewareTests.errorHandlingMiddleware.intercept(
             Test_ErrorHandlingMiddlewareTests.mockRequest,
             body: Test_ErrorHandlingMiddlewareTests.mockBody,
@@ -69,6 +71,7 @@ final class Test_ErrorHandlingMiddlewareTests: XCTestCase {
         XCTAssertEqual(response.headerFields, [:])
         XCTAssertEqual(responseBody, nil)
     }
+
     private func getNextMiddleware(failurePhase: MockErrorMiddleware_Next.FailurePhase) -> @Sendable (
         HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata
     ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {

--- a/Tests/OpenAPIRuntimeTests/Interface/Test_ErrorHandlingMiddleware.swift
+++ b/Tests/OpenAPIRuntimeTests/Interface/Test_ErrorHandlingMiddleware.swift
@@ -138,4 +138,4 @@ struct PartialConvertibleError: Error, HTTPResponseConvertible {
 
 struct NonConvertibleError: Error {}
 
-let TEST_HTTP_BODY = HTTPBody(try! JSONEncoder().encode(["error", " test error"]))
+let testHTTPBody = HTTPBody(try! JSONEncoder().encode(["error", " test error"]))


### PR DESCRIPTION
### Motivation

Implementation of [Improved error handling proposal](https://forums.swift.org/t/proposal-soar-0011-improved-error-handling/74736)

### Modifications

Added HTTPResponseConvertible protocol
Added ErrorHandlingMiddleware that converts errors confirming to HTTPResponseConvertible to a HTTP response.

### Result

The new middleware is an opt-in middleware. So there won't be any change to existing clients.
Clients who wish to have OpenAPI error handling can include the new error middleware in their application.

### Test Plan

Added E2E tests to test the new middleware.