### PR TITLE
Adopt SE-409

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,9 +16,13 @@ import PackageDescription
 
 // General Swift-settings for all targets.
 let swiftSettings: [SwiftSetting] = [
-    // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
-    // Require `any` for existential types.
-    .enableUpcomingFeature("ExistentialAny")
+    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0335-existential-any.md
+    .enableUpcomingFeature("ExistentialAny"),
+    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md
+    .enableUpcomingFeature("InternalImportsByDefault"),
+    .enableExperimentalFeature("AccessLevelOnImport"),
+    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
+    .enableUpcomingFeature("MemberImportVisibility"),
 ]
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,6 @@ let swiftSettings: [SwiftSetting] = [
     // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md
     .enableUpcomingFeature("InternalImportsByDefault"),
     .enableExperimentalFeature("AccessLevelOnImport"),
-    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
-    .enableUpcomingFeature("MemberImportVisibility"),
 ]
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -15,13 +15,17 @@
 import PackageDescription
 
 // General Swift-settings for all targets.
-let swiftSettings: [SwiftSetting] = [
+var swiftSettings: [SwiftSetting] = [
     // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0335-existential-any.md
-    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("ExistentialAny")
+]
+#if compiler(>=6.0)
+swiftSettings.append(contentsOf: [
     // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md
     .enableUpcomingFeature("InternalImportsByDefault"),
     .enableExperimentalFeature("AccessLevelOnImport"),
-]
+])
+#endif
 
 let package = Package(
     name: "swift-openapi-runtime",

--- a/Sources/OpenAPIRuntime/Base/UndocumentedPayload.swift
+++ b/Sources/OpenAPIRuntime/Base/UndocumentedPayload.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTPTypes
+public import HTTPTypes
 
 /// A payload value used by undocumented operation responses.
 ///

--- a/Sources/OpenAPIRuntime/Conversion/Configuration.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Configuration.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import Foundation
+public import Foundation
 
 /// A type that allows customization of Date encoding and decoding.
 ///

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Client.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Client.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import Foundation
-import HTTPTypes
+public import HTTPTypes
 
 extension Converter {
 

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Common.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Common.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import Foundation
-import HTTPTypes
+public import HTTPTypes
 
 extension Converter {
 

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import Foundation
-import HTTPTypes
+public import HTTPTypes
 
 extension Converter {
 

--- a/Sources/OpenAPIRuntime/Conversion/ServerVariable.swift
+++ b/Sources/OpenAPIRuntime/Conversion/ServerVariable.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
+public import Foundation
 
 extension URL {
     /// Returns a validated server URL created from the URL template, or

--- a/Sources/OpenAPIRuntime/Conversion/URLExtensions.swift
+++ b/Sources/OpenAPIRuntime/Conversion/URLExtensions.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import Foundation
+public import Foundation
 
 extension URL {
     /// Returns the default server URL of "/".

--- a/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
+++ b/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import Foundation
+public import Foundation
 import HTTPTypes
 
 // MARK: - Functionality to be removed in the future

--- a/Sources/OpenAPIRuntime/Errors/ClientError.swift
+++ b/Sources/OpenAPIRuntime/Errors/ClientError.swift
@@ -12,13 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTPTypes
+public import HTTPTypes
 #if canImport(Darwin)
-import struct Foundation.URL
+public import struct Foundation.URL
 #else
-@preconcurrency import struct Foundation.URL
+@preconcurrency public import struct Foundation.URL
 #endif
-import protocol Foundation.LocalizedError
+public import protocol Foundation.LocalizedError
 
 /// An error thrown by a client performing an OpenAPI operation.
 ///

--- a/Sources/OpenAPIRuntime/Errors/ServerError.swift
+++ b/Sources/OpenAPIRuntime/Errors/ServerError.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTPTypes
-import protocol Foundation.LocalizedError
+public import HTTPTypes
+public import protocol Foundation.LocalizedError
 
 /// An error thrown by a server handling an OpenAPI operation.
 public struct ServerError: Error {

--- a/Sources/OpenAPIRuntime/EventStreams/JSONLinesDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/JSONLinesDecoding.swift
@@ -13,11 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-import class Foundation.JSONDecoder
+public import class Foundation.JSONDecoder
 #else
-@preconcurrency import class Foundation.JSONDecoder
+@preconcurrency public import class Foundation.JSONDecoder
 #endif
-import struct Foundation.Data
+public import struct Foundation.Data
 
 /// A sequence that parses arbitrary byte chunks into lines using the JSON Lines format.
 public struct JSONLinesDeserializationSequence<Upstream: AsyncSequence & Sendable>: Sendable

--- a/Sources/OpenAPIRuntime/EventStreams/JSONLinesEncoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/JSONLinesEncoding.swift
@@ -13,9 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-import class Foundation.JSONEncoder
+public import class Foundation.JSONEncoder
 #else
-@preconcurrency import class Foundation.JSONEncoder
+@preconcurrency public import class Foundation.JSONEncoder
 #endif
 
 /// A sequence that serializes lines by concatenating them using the JSON Lines format.

--- a/Sources/OpenAPIRuntime/EventStreams/JSONSequenceDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/JSONSequenceDecoding.swift
@@ -13,12 +13,12 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-import class Foundation.JSONDecoder
+public import class Foundation.JSONDecoder
 #else
-@preconcurrency import class Foundation.JSONDecoder
+@preconcurrency public import class Foundation.JSONDecoder
 #endif
-import protocol Foundation.LocalizedError
-import struct Foundation.Data
+public import protocol Foundation.LocalizedError
+public import struct Foundation.Data
 
 /// A sequence that parses arbitrary byte chunks into lines using the JSON Sequence format.
 public struct JSONSequenceDeserializationSequence<Upstream: AsyncSequence & Sendable>: Sendable

--- a/Sources/OpenAPIRuntime/EventStreams/JSONSequenceEncoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/JSONSequenceEncoding.swift
@@ -13,9 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-import class Foundation.JSONEncoder
+public import class Foundation.JSONEncoder
 #else
-@preconcurrency import class Foundation.JSONEncoder
+@preconcurrency public import class Foundation.JSONEncoder
 #endif
 
 /// A sequence that serializes lines by concatenating them using the JSON Sequence format.

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsDecoding.swift
@@ -13,11 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-import class Foundation.JSONDecoder
+public import class Foundation.JSONDecoder
 #else
-@preconcurrency import class Foundation.JSONDecoder
+@preconcurrency public import class Foundation.JSONDecoder
 #endif
-import struct Foundation.Data
+public import struct Foundation.Data
 
 /// A sequence that parses arbitrary byte chunks into events using the Server-sent Events format.
 ///

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsEncoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsEncoding.swift
@@ -13,9 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-import class Foundation.JSONEncoder
+public import class Foundation.JSONEncoder
 #else
-@preconcurrency import class Foundation.JSONEncoder
+@preconcurrency public import class Foundation.JSONEncoder
 #endif
 
 /// A sequence that serializes Server-sent Events.

--- a/Sources/OpenAPIRuntime/Interface/ClientTransport.swift
+++ b/Sources/OpenAPIRuntime/Interface/ClientTransport.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTPTypes
-import struct Foundation.URL
+public import HTTPTypes
+public import struct Foundation.URL
 
 /// A type that performs HTTP operations.
 ///

--- a/Sources/OpenAPIRuntime/Interface/CurrencyTypes.swift
+++ b/Sources/OpenAPIRuntime/Interface/CurrencyTypes.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTPTypes
+public import HTTPTypes
 
 /// A container for request metadata already parsed and validated
 /// by the server transport.

--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTPTypes
+public import HTTPTypes
 
 /// An opt-in error handling middleware that converts an error to an HTTP response.
 ///

--- a/Sources/OpenAPIRuntime/Interface/HTTPBody.swift
+++ b/Sources/OpenAPIRuntime/Interface/HTTPBody.swift
@@ -12,9 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import class Foundation.NSLock
-import protocol Foundation.LocalizedError
-import struct Foundation.Data  // only for convenience initializers
+public import class Foundation.NSLock
+public import protocol Foundation.LocalizedError
+public import struct Foundation.Data  // only for convenience initializers
 
 /// A body of an HTTP request or HTTP response.
 ///

--- a/Sources/OpenAPIRuntime/Interface/ServerTransport.swift
+++ b/Sources/OpenAPIRuntime/Interface/ServerTransport.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTPTypes
+public import HTTPTypes
 
 /// A type that registers and handles HTTP operations.
 ///

--- a/Sources/OpenAPIRuntime/Interface/UniversalClient.swift
+++ b/Sources/OpenAPIRuntime/Interface/UniversalClient.swift
@@ -11,11 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import HTTPTypes
+public import HTTPTypes
 #if canImport(Darwin)
-import struct Foundation.URL
+public import struct Foundation.URL
 #else
-@preconcurrency import struct Foundation.URL
+@preconcurrency public import struct Foundation.URL
 #endif
 
 /// OpenAPI document-agnostic HTTP client used by OpenAPI document-specific,

--- a/Sources/OpenAPIRuntime/Interface/UniversalServer.swift
+++ b/Sources/OpenAPIRuntime/Interface/UniversalServer.swift
@@ -12,13 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTPTypes
+public import HTTPTypes
 #if canImport(Darwin)
-import struct Foundation.URL
+public import struct Foundation.URL
 #else
-@preconcurrency import struct Foundation.URL
+@preconcurrency public import struct Foundation.URL
 #endif
-import struct Foundation.URLComponents
+public import struct Foundation.URLComponents
 
 /// OpenAPI document-agnostic HTTP server used by OpenAPI document-specific,
 /// generated servers to perform request deserialization, middleware and handler

--- a/Sources/OpenAPIRuntime/Multipart/MultipartPublicTypes.swift
+++ b/Sources/OpenAPIRuntime/Multipart/MultipartPublicTypes.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import HTTPTypes
+public import HTTPTypes
 
 /// A raw multipart part containing the header fields and the body stream.
 public struct MultipartRawPart: Sendable, Hashable {

--- a/Sources/OpenAPIRuntime/Multipart/MultipartPublicTypesExtensions.swift
+++ b/Sources/OpenAPIRuntime/Multipart/MultipartPublicTypesExtensions.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import HTTPTypes
+public import HTTPTypes
 
 // MARK: - Extensions
 

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Client.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Client.swift
@@ -275,7 +275,7 @@ final class Test_ClientConverterExtensions: Test_Runtime {
 ///   - message: An optional custom message to display upon test failure.
 ///   - file: The file name to include in the failure message (default is the source file where this function is called).
 ///   - line: The line number to include in the failure message (default is the line where this function is called).
-public func XCTAssertEqualStringifiedData(
+func XCTAssertEqualStringifiedData(
     _ expression1: @autoclosure () throws -> Data,
     _ expression2: @autoclosure () throws -> String,
     _ message: @autoclosure () -> String = "",

--- a/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
+++ b/Tests/OpenAPIRuntimeTests/Test_Runtime.swift
@@ -259,7 +259,7 @@ struct MockCustomCoder: CustomCoder {
 ///   - rhs: The expected absolute string representation.
 ///   - file: The file name to include in the failure message (default is the source file where this function is called).
 ///   - line: The line number to include in the failure message (default is the line where this function is called).
-public func XCTAssertEqualURLString(_ lhs: URL?, _ rhs: String, file: StaticString = #filePath, line: UInt = #line) {
+func XCTAssertEqualURLString(_ lhs: URL?, _ rhs: String, file: StaticString = #filePath, line: UInt = #line) {
     guard let lhs else {
         XCTFail("URL is nil")
         return
@@ -384,7 +384,7 @@ public func XCTAssertEqualStringifiedData<S: Sequence>(
 ///   - file: The file name to include in the failure message (default is the source file where this function is called).
 ///   - line: The line number to include in the failure message (default is the line where this function is called).
 /// - Throws: If either of the autoclosures throws an error, the function will rethrow that error.
-public func XCTAssertEqualStringifiedData(
+func XCTAssertEqualStringifiedData(
     _ expression1: @autoclosure () throws -> HTTPBody?,
     _ expression2: @autoclosure () throws -> String,
     _ message: @autoclosure () -> String = "",
@@ -474,7 +474,7 @@ public func XCTAssertEqualAsyncData<C: Collection, AS: AsyncSequence>(
 }
 
 /// Asserts that the data matches the expected value.
-public func XCTAssertEqualData<C: Collection>(
+func XCTAssertEqualData<C: Collection>(
     _ expression1: @autoclosure () throws -> HTTPBody?,
     _ expression2: @autoclosure () throws -> C,
     _ message: @autoclosure () -> String = "Data doesn't match.",


### PR DESCRIPTION
### Motivation

- https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md

### Modifications

Added explicitly access modifiers on imports.

### Result

Made it more explicit which types we're importing publicly and are used in our own API.

### Test Plan

Tests passed, will let CI ensure this works in all our supported Swift versions.
