### PR TITLE
Conform RuntimeError to HTTPResponseConvertible

### DIFF
--- a/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
+++ b/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
@@ -142,41 +142,24 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
     throw RuntimeError.unexpectedResponseBody(expectedContent: expectedContent, body: body)
 }
 
-/// HTTP Response status definition for ``RuntimeError``. 
+/// HTTP Response status definition for ``RuntimeError``.
 extension RuntimeError: HTTPResponseConvertible {
+    /// HTTP Status code corresponding to each error case
     public var httpStatus: HTTPTypes.HTTPResponse.Status {
         switch self {
-        case .invalidServerURL,
-                .invalidServerVariableValue:
-            .notFound
-        case .invalidExpectedContentType,
-                .missingCoderForCustomContentType,
-                .unexpectedContentTypeHeader:
-            .unsupportedMediaType
-        case .unexpectedAcceptHeader(_):
-            .notAcceptable
-        case .missingOrMalformedContentDispositionName:
-            .unprocessableContent
-        case .failedToDecodeStringConvertibleValue,
-                .invalidAcceptSubstring,
-                .invalidBase64String,
-                .invalidHeaderFieldName,
-                .malformedAcceptHeader,
-                .missingMultipartBoundaryContentTypeParameter,
-                .missingRequiredHeaderField,
-                .missingRequiredMultipartFormDataContentType,
-                .missingRequiredQueryParameter,
-                .missingRequiredPathParameter,
-                .missingRequiredRequestBody,
-                .pathUnset,
-                .unsupportedParameterStyle:
+        case .invalidServerURL, .invalidServerVariableValue: .notFound
+        case .invalidExpectedContentType, .unexpectedContentTypeHeader: .unsupportedMediaType
+        case .missingCoderForCustomContentType: .unprocessableContent
+        case .unexpectedAcceptHeader: .notAcceptable
+        case .failedToDecodeStringConvertibleValue, .invalidAcceptSubstring, .invalidBase64String,
+            .invalidHeaderFieldName, .malformedAcceptHeader, .missingMultipartBoundaryContentTypeParameter,
+            .missingOrMalformedContentDispositionName, .missingRequiredHeaderField,
+            .missingRequiredMultipartFormDataContentType, .missingRequiredQueryParameter, .missingRequiredPathParameter,
+            .missingRequiredRequestBody, .unsupportedParameterStyle:
             .badRequest
-        case .handlerFailed,
-                .middlewareFailed,
-                .missingRequiredResponseBody,
-                .transportFailed,
-                .unexpectedResponseStatus,
-                .unexpectedResponseBody:
+        case .pathUnset: .notFound
+        case .handlerFailed, .middlewareFailed, .missingRequiredResponseBody, .transportFailed,
+            .unexpectedResponseStatus, .unexpectedResponseBody:
             .internalServerError
         }
     }

--- a/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
+++ b/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import protocol Foundation.LocalizedError
 import struct Foundation.Data
-
+import HTTPTypes
 /// Error thrown by generated code.
 internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, PrettyStringConvertible {
 
@@ -140,4 +140,44 @@ internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, Pret
 /// - Throws: An error indicating an unexpected response body content.
 @_spi(Generated) public func throwUnexpectedResponseBody(expectedContent: String, body: any Sendable) throws -> Never {
     throw RuntimeError.unexpectedResponseBody(expectedContent: expectedContent, body: body)
+}
+
+/// HTTP Response status definition for ``RuntimeError``. 
+extension RuntimeError: HTTPResponseConvertible {
+    public var httpStatus: HTTPTypes.HTTPResponse.Status {
+        switch self {
+        case .invalidServerURL,
+                .invalidServerVariableValue:
+            .notFound
+        case .invalidExpectedContentType,
+                .missingCoderForCustomContentType,
+                .unexpectedContentTypeHeader:
+            .unsupportedMediaType
+        case .unexpectedAcceptHeader(_):
+            .notAcceptable
+        case .missingOrMalformedContentDispositionName:
+            .unprocessableContent
+        case .failedToDecodeStringConvertibleValue,
+                .invalidAcceptSubstring,
+                .invalidBase64String,
+                .invalidHeaderFieldName,
+                .malformedAcceptHeader,
+                .missingMultipartBoundaryContentTypeParameter,
+                .missingRequiredHeaderField,
+                .missingRequiredMultipartFormDataContentType,
+                .missingRequiredQueryParameter,
+                .missingRequiredPathParameter,
+                .missingRequiredRequestBody,
+                .pathUnset,
+                .unsupportedParameterStyle:
+            .badRequest
+        case .handlerFailed,
+                .middlewareFailed,
+                .missingRequiredResponseBody,
+                .transportFailed,
+                .unexpectedResponseStatus,
+                .unexpectedResponseBody:
+            .internalServerError
+        }
+    }
 }

--- a/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
+++ b/Sources/OpenAPIRuntime/Errors/RuntimeError.swift
@@ -14,6 +14,7 @@
 import protocol Foundation.LocalizedError
 import struct Foundation.Data
 import HTTPTypes
+
 /// Error thrown by generated code.
 internal enum RuntimeError: Error, CustomStringConvertible, LocalizedError, PrettyStringConvertible {
 
@@ -147,7 +148,7 @@ extension RuntimeError: HTTPResponseConvertible {
     /// HTTP Status code corresponding to each error case
     public var httpStatus: HTTPTypes.HTTPResponse.Status {
         switch self {
-        case .invalidServerURL, .invalidServerVariableValue: .notFound
+        case .invalidServerURL, .invalidServerVariableValue, .pathUnset: .notFound
         case .invalidExpectedContentType, .unexpectedContentTypeHeader: .unsupportedMediaType
         case .missingCoderForCustomContentType: .unprocessableContent
         case .unexpectedAcceptHeader: .notAcceptable
@@ -157,7 +158,6 @@ extension RuntimeError: HTTPResponseConvertible {
             .missingRequiredMultipartFormDataContentType, .missingRequiredQueryParameter, .missingRequiredPathParameter,
             .missingRequiredRequestBody, .unsupportedParameterStyle:
             .badRequest
-        case .pathUnset: .notFound
         case .handlerFailed, .middlewareFailed, .missingRequiredResponseBody, .transportFailed,
             .unexpectedResponseStatus, .unexpectedResponseBody:
             .internalServerError

--- a/Tests/OpenAPIRuntimeTests/Errors/Test_RuntimeError.swift
+++ b/Tests/OpenAPIRuntimeTests/Errors/Test_RuntimeError.swift
@@ -19,7 +19,7 @@ import XCTest
 struct MockRuntimeErrorHandler: Sendable {
     var failWithError: (any Error)? = nil
     func greet(_ input: String) async throws -> String {
-        if failWithError != nil { throw failWithError! }
+        if let failWithError { throw failWithError }
         guard input == "hello" else { throw TestError() }
         return "bye"
     }

--- a/Tests/OpenAPIRuntimeTests/Errors/Test_RuntimeError.swift
+++ b/Tests/OpenAPIRuntimeTests/Errors/Test_RuntimeError.swift
@@ -29,7 +29,7 @@ struct MockRuntimeErrorHandler: Sendable {
 }
 
 final class Test_RuntimeError: XCTestCase {
-    func testRuntimeError_withUnderlyingErrorNotConfirming_returns500() async throws {
+    func testRuntimeError_withUnderlyingErrorNotConforming_returns500() async throws {
         let server = UniversalServer(
             handler: MockRuntimeErrorHandler(failWithError: RuntimeError.transportFailed(TestError())),
             middlewares: [ErrorHandlingMiddleware()]
@@ -49,7 +49,7 @@ final class Test_RuntimeError: XCTestCase {
         XCTAssertEqual(response.0.status, .internalServerError)
     }
 
-    func testRuntimeError_withUnderlyingErrorConfirming_returnsCorrectStatusCode() async throws {
+    func testRuntimeError_withUnderlyingErrorConforming_returnsCorrectStatusCode() async throws {
         let server = UniversalServer(
             handler: MockRuntimeErrorHandler(failWithError: TestErrorConvertible.testError("Test Error")),
             middlewares: [ErrorHandlingMiddleware()]

--- a/Tests/OpenAPIRuntimeTests/Errors/Test_RuntimeError.swift
+++ b/Tests/OpenAPIRuntimeTests/Errors/Test_RuntimeError.swift
@@ -29,11 +29,11 @@ struct MockRuntimeErrorHandler: Sendable {
 }
 
 final class Test_RuntimeError: XCTestCase {
-    
     func testRuntimeError_withUnderlyingErrorNotConfirming_returns500() async throws {
-        
-        let server = UniversalServer(handler: MockRuntimeErrorHandler(failWithError: RuntimeError.transportFailed(TestError())),
-                                     middlewares: [ErrorHandlingMiddleware()])
+        let server = UniversalServer(
+            handler: MockRuntimeErrorHandler(failWithError: RuntimeError.transportFailed(TestError())),
+            middlewares: [ErrorHandlingMiddleware()]
+        )
         let response = try await server.handle(
             request: .init(soar_path: "/", method: .post),
             requestBody: MockHandler.requestBody,
@@ -50,9 +50,10 @@ final class Test_RuntimeError: XCTestCase {
     }
 
     func testRuntimeError_withUnderlyingErrorConfirming_returnsCorrectStatusCode() async throws {
-        
-        let server = UniversalServer(handler: MockRuntimeErrorHandler(failWithError: TestErrorConvertible.testError("Test Error")),
-                                     middlewares: [ErrorHandlingMiddleware()])
+        let server = UniversalServer(
+            handler: MockRuntimeErrorHandler(failWithError: TestErrorConvertible.testError("Test Error")),
+            middlewares: [ErrorHandlingMiddleware()]
+        )
         let response = try await server.handle(
             request: .init(soar_path: "/", method: .post),
             requestBody: MockHandler.requestBody,
@@ -71,11 +72,6 @@ final class Test_RuntimeError: XCTestCase {
 
 enum TestErrorConvertible: Error, HTTPResponseConvertible {
     case testError(String)
-    
     /// HTTP status code for error cases
-    public var httpStatus: HTTPTypes.HTTPResponse.Status {
-        .badGateway
-    }
+    public var httpStatus: HTTPTypes.HTTPResponse.Status { .badGateway }
 }
-
-

--- a/Tests/OpenAPIRuntimeTests/Errors/Test_RuntimeError.swift
+++ b/Tests/OpenAPIRuntimeTests/Errors/Test_RuntimeError.swift
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HTTPTypes
+@_spi(Generated) @testable import OpenAPIRuntime
+import XCTest
+
+struct MockRuntimeErrorHandler: Sendable {
+    var failWithError: (any Error)? = nil
+    func greet(_ input: String) async throws -> String {
+        if failWithError != nil { throw failWithError! }
+        guard input == "hello" else { throw TestError() }
+        return "bye"
+    }
+
+    static let requestBody: HTTPBody = HTTPBody("hello")
+    static let responseBody: HTTPBody = HTTPBody("bye")
+}
+
+final class Test_RuntimeError: XCTestCase {
+    func testRuntimeError_returnsCorrectStatusCode() async throws {
+        
+        let server = UniversalServer(handler: MockRuntimeErrorHandler(failWithError: RuntimeError.invalidServerURL("Invalid server URL")),
+                                     middlewares: [ErrorHandlingMiddleware()])
+        let response = try await server.handle(
+            request: .init(soar_path: "/", method: .post),
+            requestBody: MockHandler.requestBody,
+            metadata: .init(),
+            forOperation: "op",
+            using: { MockRuntimeErrorHandler.greet($0) },
+            deserializer: { request, body, metadata in
+                let body = try XCTUnwrap(body)
+                return try await String(collecting: body, upTo: 10)
+            },
+            serializer: { output, _ in fatalError() }
+        )
+        XCTAssertEqual(response.0.status, .notFound)
+    }
+    
+    func testRuntimeError_withUnderlyingErrorNotConfirming_returns500() async throws {
+        
+        let server = UniversalServer(handler: MockRuntimeErrorHandler(failWithError: RuntimeError.transportFailed(TestError())),
+                                     middlewares: [ErrorHandlingMiddleware()])
+        let response = try await server.handle(
+            request: .init(soar_path: "/", method: .post),
+            requestBody: MockHandler.requestBody,
+            metadata: .init(),
+            forOperation: "op",
+            using: { MockRuntimeErrorHandler.greet($0) },
+            deserializer: { request, body, metadata in
+                let body = try XCTUnwrap(body)
+                return try await String(collecting: body, upTo: 10)
+            },
+            serializer: { output, _ in fatalError() }
+        )
+        XCTAssertEqual(response.0.status, .internalServerError)
+    }
+
+    func testRuntimeError_withUnderlyingErrorConfirming_returns500() async throws {
+        
+        let server = UniversalServer(handler: MockRuntimeErrorHandler(failWithError: TestErrorConvertible.testError("Test Error")),
+                                     middlewares: [ErrorHandlingMiddleware()])
+        let response = try await server.handle(
+            request: .init(soar_path: "/", method: .post),
+            requestBody: MockHandler.requestBody,
+            metadata: .init(),
+            forOperation: "op",
+            using: { MockRuntimeErrorHandler.greet($0) },
+            deserializer: { request, body, metadata in
+                let body = try XCTUnwrap(body)
+                return try await String(collecting: body, upTo: 10)
+            },
+            serializer: { output, _ in fatalError() }
+        )
+        XCTAssertEqual(response.0.status, .badGateway)
+    }
+}
+
+enum TestErrorConvertible: Error, HTTPResponseConvertible {
+    case testError(String)
+    
+    public var httpStatus: HTTPTypes.HTTPResponse.Status {
+        .badGateway
+    }
+}
+
+


### PR DESCRIPTION
### Motivation

https://github.com/apple/swift-openapi-generator/issues/609#issuecomment-2522503704

### Modifications

Confirm `RuntimeError` to `HTTPResponseConvertible` and provide granular status codes.

### Result

Response codes for bad user input will be 4xx (instead of 500)

### Test Plan

Unit tests.