### PR TITLE
Add HTTPResponseError

### DIFF
--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -74,7 +74,8 @@ public struct ErrorHandlingMiddleware: ServerMiddleware {
 ///
 /// Conform your error type to this protocol to convert it to an `HTTPResponse` and ``HTTPBody``.
 ///
-/// Used by ``ErrorHandlingMiddleware``.
+/// You must provide ``ErrorHandlingMiddleware`` to `registerHandlers` in order for
+/// this value to get converted to the desired HTTP response.
 public protocol HTTPResponseConvertible {
 
     /// An HTTP status to return in the response.
@@ -95,4 +96,37 @@ extension HTTPResponseConvertible {
 
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var httpBody: OpenAPIRuntime.HTTPBody? { nil }
+}
+
+/// An concrete error type that represents a desired HTTP response to be returned by the server.
+///
+/// Throw this error in your API handler to return a specific undocumented HTTP response.
+///
+/// You must provide ``ErrorHandlingMiddleware`` to `registerHandlers` in order for
+/// this error to get converted to the desired HTTP response.
+public struct HTTPResponseError: Error, HTTPResponseConvertible {
+
+    /// An HTTP status to return in the response.
+    public var httpStatus: HTTPResponse.Status
+
+    /// The HTTP header fields of the response.
+    public var httpHeaderFields: HTTPTypes.HTTPFields
+
+    /// The body of the HTTP response.
+    public var httpBody: OpenAPIRuntime.HTTPBody?
+
+    /// Creates a new error.
+    /// - Parameters:
+    ///   - httpStatus: An HTTP status to return in the response.
+    ///   - httpHeaderFields: The HTTP header fields of the response.
+    ///   - httpBody: The body of the HTTP response.
+    public init(
+        httpStatus: HTTPResponse.Status,
+        httpHeaderFields: HTTPTypes.HTTPFields = [:],
+        httpBody: OpenAPIRuntime.HTTPBody? = nil
+    ) {
+        self.httpStatus = httpStatus
+        self.httpHeaderFields = httpHeaderFields
+        self.httpBody = httpBody
+    }
 }


### PR DESCRIPTION
### Motivation

When throwing `HTTPResponseConvertible`-conforming types from middlewares and utility functions, I often find myself just creating a single type for the whole project that represents an "HTTP response error", matching the protocol exactly - just as a concrete struct that conforms to error.

This might be more generally useful, and having one in the runtime library avoids others needing to do the same.

Domain-specific errors can continue to conform to HTTPResponseConvertible, this is just for the cases where a domain-specific error isn't adding much beyond the status code (for example, throwing a 401 out of an authentication server middleware.)

### Modifications

Added `HTTPResponseError`, which provides a convenience type mirroring `HTTPResponseConvertible`.

### Result

Adopters can use this type, rather than write their own similar/identical one.

### Test Plan

Just a struct with stored properties, no other logic.
