### PR TITLE
ClientError: don't call our to localizedDescription in description

### DIFF
--- a/Sources/OpenAPIRuntime/Errors/ClientError.swift
+++ b/Sources/OpenAPIRuntime/Errors/ClientError.swift
@@ -110,7 +110,7 @@ public struct ClientError: Error {
 
     fileprivate var underlyingErrorDescription: String {
         guard let prettyError = underlyingError as? (any PrettyStringConvertible) else {
-            return underlyingError.localizedDescription
+            return "\(underlyingError)"
         }
         return prettyError.prettyDescription
     }


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apple/swift-openapi-generator/issues/730 . LocalizedDescription doesn't print anything useful for Swift Errors. It just prints `ErrorType code 1` regardless what the underlying issue was.

That is unacceptable in production software.

### Modifications

Correct `description` to call `description`/`String(describing:)`.

### Result

Can debug software regardless of the transport.

### Test Plan

_[Describe the steps you took, or will take, to qualify the change - such as adjusting tests and manual testing.]_
