### PR TITLE
Custom error mapper

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/Configuration.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Configuration.swift
@@ -166,7 +166,8 @@ public struct Configuration: Sendable {
     ///   - jsonEncodingOptions: The options for the underlying JSON encoder.
     ///   - multipartBoundaryGenerator: The generator to use when creating mutlipart bodies.
     ///   - xmlCoder: Custom XML coder for encoding and decoding xml bodies. Only required when using XML body payloads.
-    ///   - errorMapper: An error mapping closure to allow customizing the final error thrown.
+    ///   - clientErrorMapper: An error mapping closure to allow customizing the error thrown by the client.
+    ///   - serverErrorMapper: An error mapping closure to allow customizing the error thrown by the server.
     public init(
         dateTranscoder: any DateTranscoder = .iso8601,
         jsonEncodingOptions: JSONEncodingOptions = [.sortedKeys, .prettyPrinted],

--- a/Sources/OpenAPIRuntime/Conversion/Configuration.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Configuration.swift
@@ -152,6 +152,12 @@ public struct Configuration: Sendable {
     /// Custom XML coder for encoding and decoding xml bodies.
     public var xmlCoder: (any CustomCoder)?
 
+    /// An error mapping closure to allow customizing the error thrown by the client.
+    public var clientErrorMapper: (@Sendable (ClientError) -> any Error)?
+
+    /// An error mapping closure to allow customizing the error thrown by the server.
+    public var serverErrorMapper: (@Sendable (ServerError) -> any Error)?
+
     /// Creates a new configuration with the specified values.
     ///
     /// - Parameters:
@@ -160,15 +166,20 @@ public struct Configuration: Sendable {
     ///   - jsonEncodingOptions: The options for the underlying JSON encoder.
     ///   - multipartBoundaryGenerator: The generator to use when creating mutlipart bodies.
     ///   - xmlCoder: Custom XML coder for encoding and decoding xml bodies. Only required when using XML body payloads.
+    ///   - errorMapper: An error mapping closure to allow customizing the final error thrown.
     public init(
         dateTranscoder: any DateTranscoder = .iso8601,
         jsonEncodingOptions: JSONEncodingOptions = [.sortedKeys, .prettyPrinted],
         multipartBoundaryGenerator: any MultipartBoundaryGenerator = .random,
-        xmlCoder: (any CustomCoder)? = nil
+        xmlCoder: (any CustomCoder)? = nil,
+        clientErrorMapper: (@Sendable (ClientError) -> any Error)? = nil,
+        serverErrorMapper: (@Sendable (ServerError) -> any Error)? = nil
     ) {
         self.dateTranscoder = dateTranscoder
         self.jsonEncodingOptions = jsonEncodingOptions
         self.multipartBoundaryGenerator = multipartBoundaryGenerator
         self.xmlCoder = xmlCoder
+        self.clientErrorMapper = clientErrorMapper
+        self.serverErrorMapper = serverErrorMapper
     }
 }

--- a/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
+++ b/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
@@ -67,8 +67,12 @@ extension Configuration {
     ///   - jsonEncodingOptions: The options for the underlying JSON encoder.
     ///   - multipartBoundaryGenerator: The generator to use when creating mutlipart bodies.
     ///   - xmlCoder: Custom XML coder for encoding and decoding xml bodies. Only required when using XML body payloads.
-    @available(*, deprecated, renamed: "init(dateTranscoder:jsonEncodingOptions:multipartBoundaryGenerator:xmlCoder:clientErrorMapper:serverErrorMapper:)")
-    @_disfavoredOverload public init(
+    @available(
+        *,
+        deprecated,
+        renamed:
+            "init(dateTranscoder:jsonEncodingOptions:multipartBoundaryGenerator:xmlCoder:clientErrorMapper:serverErrorMapper:)"
+    ) @_disfavoredOverload public init(
         dateTranscoder: any DateTranscoder = .iso8601,
         jsonEncodingOptions: JSONEncodingOptions = [.sortedKeys, .prettyPrinted],
         multipartBoundaryGenerator: any MultipartBoundaryGenerator = .random,

--- a/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
+++ b/Sources/OpenAPIRuntime/Deprecated/Deprecated.swift
@@ -58,6 +58,31 @@ extension Configuration {
             xmlCoder: xmlCoder
         )
     }
+
+    /// Creates a new configuration with the specified values.
+    ///
+    /// - Parameters:
+    ///   - dateTranscoder: The transcoder to use when converting between date
+    ///   and string values.
+    ///   - jsonEncodingOptions: The options for the underlying JSON encoder.
+    ///   - multipartBoundaryGenerator: The generator to use when creating mutlipart bodies.
+    ///   - xmlCoder: Custom XML coder for encoding and decoding xml bodies. Only required when using XML body payloads.
+    @available(*, deprecated, renamed: "init(dateTranscoder:jsonEncodingOptions:multipartBoundaryGenerator:xmlCoder:clientErrorMapper:serverErrorMapper:)")
+    @_disfavoredOverload public init(
+        dateTranscoder: any DateTranscoder = .iso8601,
+        jsonEncodingOptions: JSONEncodingOptions = [.sortedKeys, .prettyPrinted],
+        multipartBoundaryGenerator: any MultipartBoundaryGenerator = .random,
+        xmlCoder: (any CustomCoder)? = nil
+    ) {
+        self.init(
+            dateTranscoder: dateTranscoder,
+            jsonEncodingOptions: [.sortedKeys, .prettyPrinted],
+            multipartBoundaryGenerator: multipartBoundaryGenerator,
+            xmlCoder: xmlCoder,
+            clientErrorMapper: nil,
+            serverErrorMapper: nil
+        )
+    }
 }
 
 extension AsyncSequence where Element == ArraySlice<UInt8>, Self: Sendable {

--- a/Sources/OpenAPIRuntime/Interface/UniversalClient.swift
+++ b/Sources/OpenAPIRuntime/Interface/UniversalClient.swift
@@ -61,15 +61,14 @@ import struct Foundation.URL
         serverURL: URL = .defaultOpenAPIServerURL,
         configuration: Configuration = .init(),
         transport: any ClientTransport,
-        middlewares: [any ClientMiddleware] = [],
-        errorMapper: (@Sendable (ClientError) -> any Error)? = nil
+        middlewares: [any ClientMiddleware] = []
     ) {
         self.init(
             serverURL: serverURL,
             converter: Converter(configuration: configuration),
             transport: transport,
             middlewares: middlewares,
-            errorMapper: errorMapper
+            errorMapper: configuration.clientErrorMapper
         )
     }
 

--- a/Sources/OpenAPIRuntime/Interface/UniversalServer.swift
+++ b/Sources/OpenAPIRuntime/Interface/UniversalServer.swift
@@ -180,9 +180,7 @@ import struct Foundation.URLComponents
                 }
             }
         }
-        do {
-            return try await next(request, requestBody, metadata)
-        } catch {
+        do { return try await next(request, requestBody, metadata) } catch {
             if let errorMapper, let serverError = error as? ServerError {
                 throw errorMapper(serverError)
             } else {

--- a/Tests/OpenAPIRuntimeTests/Interface/Test_UniversalClient.swift
+++ b/Tests/OpenAPIRuntimeTests/Interface/Test_UniversalClient.swift
@@ -122,12 +122,10 @@ final class Test_UniversalClient: Test_Runtime {
     func testErrorPropagation_customErrorMapper() async throws {
         do {
             let client = UniversalClient(
-                configuration: .init(
-                    clientErrorMapper: { clientError in
-                        // Don't care about the extra context, just wants the underlyingError
-                        clientError.underlyingError
-                    }
-                ),
+                configuration: .init(clientErrorMapper: { clientError in
+                    // Don't care about the extra context, just wants the underlyingError
+                    clientError.underlyingError
+                }),
                 transport: MockClientTransport.failing
             )
             try await client.send(
@@ -136,9 +134,7 @@ final class Test_UniversalClient: Test_Runtime {
                 serializer: { input in (HTTPRequest(soar_path: "/", method: .post), MockClientTransport.requestBody) },
                 deserializer: { response, body in fatalError() }
             )
-        } catch {
-            XCTAssertTrue(error is TestError, "Threw an unexpected error: \(type(of: error))")
-        }
+        } catch { XCTAssertTrue(error is TestError, "Threw an unexpected error: \(type(of: error))") }
     }
 
     func testErrorPropagation_middlewareOnResponse() async throws {

--- a/Tests/OpenAPIRuntimeTests/Interface/Test_UniversalClient.swift
+++ b/Tests/OpenAPIRuntimeTests/Interface/Test_UniversalClient.swift
@@ -122,11 +122,13 @@ final class Test_UniversalClient: Test_Runtime {
     func testErrorPropagation_customErrorMapper() async throws {
         do {
             let client = UniversalClient(
-                transport: MockClientTransport.failing,
-                errorMapper: { clientError in
-                    // Don't care about the extra context, just wants the underlyingError
-                    clientError.underlyingError
-                }
+                configuration: .init(
+                    clientErrorMapper: { clientError in
+                        // Don't care about the extra context, just wants the underlyingError
+                        clientError.underlyingError
+                    }
+                ),
+                transport: MockClientTransport.failing
             )
             try await client.send(
                 input: "input",

--- a/Tests/OpenAPIRuntimeTests/Interface/Test_UniversalServer.swift
+++ b/Tests/OpenAPIRuntimeTests/Interface/Test_UniversalServer.swift
@@ -133,12 +133,10 @@ final class Test_UniversalServer: Test_Runtime {
         do {
             let server = UniversalServer(
                 handler: MockHandler(shouldFail: true),
-                configuration: .init(
-                    serverErrorMapper: { serverError in
-                        // Don't care about the extra context, just wants the underlyingError
-                        serverError.underlyingError
-                    }
-                )
+                configuration: .init(serverErrorMapper: { serverError in
+                    // Don't care about the extra context, just wants the underlyingError
+                    serverError.underlyingError
+                })
             )
             _ = try await server.handle(
                 request: .init(soar_path: "/", method: .post),
@@ -152,9 +150,7 @@ final class Test_UniversalServer: Test_Runtime {
                 },
                 serializer: { output, _ in fatalError() }
             )
-        } catch {
-            XCTAssertTrue(error is TestError, "Threw an unexpected error: \(type(of: error))")
-        }
+        } catch { XCTAssertTrue(error is TestError, "Threw an unexpected error: \(type(of: error))") }
     }
 
     func testErrorPropagation_serializer() async throws {


### PR DESCRIPTION
### Motivation

In some cases, the caller doesn't want to explicitly catch the `ClientError` and extract the underlyingError from it, and just want the underlying error (thrown by the generated code, middleware, or handler). Before this change, that required wrapping all calls to the client with a special closure that'd unwrap the error, but this should be moved into the client itself.

Similarly, on the server, some adopters might not be interested in the extra context in the final `ServerError` error thrown down the middleware path, and just want the underlying error.

Also drafted more comprehensive error handling docs, which would include this new feature: https://github.com/apple/swift-openapi-generator/pull/733

### Modifications

Add an error mapper customization point, one for client errors, one for server.

This allows the following now:

```swift
let client = Client(
    serverURL: try Servers.server1.url(), 
    configuration: .init(clientErrorMapper: { clientError in
        // Always throw the underlying error, discard the extra context
        clientError.underlyingError
    }),
    transport: URLSessionTransport()
)

do {
    let response = try await client.greet()
} catch {
    print(error) // this error is now the underlyingError, rather than ClientError
}
```

Tip: since this PR changes some indentation, it's easier to review with whitespace ignored: https://github.com/apple/swift-openapi-runtime/pull/141/files?w=1

### Result

More flexibility when it comes to error handling.

### Test Plan

Added a unit test.

