### PR TITLE
[CI] Enable Windows unit tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,12 @@ jobs:
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_6_0_enabled: true
+      windows_nightly_6_1_enabled: true
+      windows_nightly_main_enabled: true
+      windows_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   integration-test:
     name: Integration test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,6 +20,12 @@ jobs:
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_6_0_enabled: true
+      windows_nightly_6_1_enabled: true
+      windows_nightly_main_enabled: true
+      windows_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   integration-test:
     name: Integration test


### PR DESCRIPTION
### Motivation

First step of https://github.com/apple/swift-openapi-generator/issues/736.

### Modifications

Enabled Windows CI for unit tests, both on PRs and main.

Did not enable integration tests yet.

### Result

See if Windows CI passes.

### Test Plan

Observe PR CI.
