### PR TITLE
Only apply standard swift settings on valid targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,15 +23,31 @@ let swiftSettings: [SwiftSetting] = [
 
 let package = Package(
     name: "swift-openapi-runtime",
-    platforms: [.macOS(.v10_15), .macCatalyst(.v13), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .visionOS(.v1)],
-    products: [.library(name: "OpenAPIRuntime", targets: ["OpenAPIRuntime"])],
-    dependencies: [.package(url: "https://github.com/apple/swift-http-types", from: "1.0.0")],
+    platforms: [
+        .macOS(.v10_15), .macCatalyst(.v13), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .visionOS(.v1)
+    ],
+    products: [
+        .library(
+            name: "OpenAPIRuntime",
+            targets: ["OpenAPIRuntime"]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-http-types", from: "1.0.0"),
+    ],
     targets: [
         .target(
             name: "OpenAPIRuntime",
-            dependencies: [.product(name: "HTTPTypes", package: "swift-http-types")],
+            dependencies: [
+                .product(name: "HTTPTypes", package: "swift-http-types")
+            ],
             swiftSettings: swiftSettings
-        ), .testTarget(name: "OpenAPIRuntimeTests", dependencies: ["OpenAPIRuntime"], swiftSettings: swiftSettings),
+        ),
+        .testTarget(
+            name: "OpenAPIRuntimeTests",
+            dependencies: ["OpenAPIRuntime"],
+            swiftSettings: swiftSettings
+        ),
     ]
 )
 
@@ -46,4 +62,5 @@ for target in package.targets {
     case .macro, .plugin, .system, .binary: ()  // not applicable
     @unknown default: ()  // we don't know what to do here, do nothing
     }
-}// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //
+}
+// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //

--- a/Package.swift
+++ b/Package.swift
@@ -23,41 +23,27 @@ let swiftSettings: [SwiftSetting] = [
 
 let package = Package(
     name: "swift-openapi-runtime",
-    platforms: [
-        .macOS(.v10_15), .macCatalyst(.v13), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .visionOS(.v1)
-    ],
-    products: [
-        .library(
-            name: "OpenAPIRuntime",
-            targets: ["OpenAPIRuntime"]
-        )
-    ],
-    dependencies: [
-        .package(url: "https://github.com/apple/swift-http-types", from: "1.0.0"),
-    ],
+    platforms: [.macOS(.v10_15), .macCatalyst(.v13), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .visionOS(.v1)],
+    products: [.library(name: "OpenAPIRuntime", targets: ["OpenAPIRuntime"])],
+    dependencies: [.package(url: "https://github.com/apple/swift-http-types", from: "1.0.0")],
     targets: [
         .target(
             name: "OpenAPIRuntime",
-            dependencies: [
-                .product(name: "HTTPTypes", package: "swift-http-types")
-            ],
+            dependencies: [.product(name: "HTTPTypes", package: "swift-http-types")],
             swiftSettings: swiftSettings
-        ),
-        .testTarget(
-            name: "OpenAPIRuntimeTests",
-            dependencies: ["OpenAPIRuntime"],
-            swiftSettings: swiftSettings
-        ),
+        ), .testTarget(name: "OpenAPIRuntimeTests", dependencies: ["OpenAPIRuntime"], swiftSettings: swiftSettings),
     ]
 )
 
 // ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
 for target in package.targets {
-    if target.type != .plugin {
+    switch target.type {
+    case .regular, .test, .executable:
         var settings = target.swiftSettings ?? []
         // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
         settings.append(.enableUpcomingFeature("MemberImportVisibility"))
         target.swiftSettings = settings
+    case .macro, .plugin, .system, .binary: ()  // not applicable
+    @unknown default: ()  // we don't know what to do here, do nothing
     }
-}
-// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //
+}// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //


### PR DESCRIPTION
Only apply standard swift settings on valid targets. The current check ignores plugins but that is not comprehensive enough.