### PR TITLE
Add support for Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,12 @@ jobs:
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_6_0_enabled: true
+      windows_nightly_6_1_enabled: true
+      windows_nightly_main_enabled: true
+      windows_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   integration-test:
     name: Integration test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,6 +20,12 @@ jobs:
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_6_0_enabled: true
+      windows_nightly_6_1_enabled: true
+      windows_nightly_main_enabled: true
+      windows_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   integration-test:
     name: Integration test

--- a/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
+++ b/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
@@ -19,7 +19,9 @@ import class Foundation.NSNull
 @preconcurrency import class Foundation.NSNull
 #endif
 import class Foundation.NSNumber
+#if canImport(CoreFoundation)
 import CoreFoundation
+#endif
 #endif
 
 /// A container for a value represented by JSON Schema.
@@ -141,10 +143,12 @@ public struct OpenAPIValueContainer: Codable, Hashable, Sendable {
             try container.encodeNil()
             return
         }
+        #if canImport(CoreFoundation)
         if let nsNumber = value as? NSNumber {
             try encode(nsNumber, to: &container)
             return
         }
+        #endif
         #endif
         switch value {
         case let value as Bool: try container.encode(value)
@@ -162,6 +166,7 @@ public struct OpenAPIValueContainer: Codable, Hashable, Sendable {
             )
         }
     }
+    #if canImport(CoreFoundation)
     /// Encodes the provided NSNumber based on its internal representation.
     /// - Parameters:
     ///   - value: The NSNumber that boxes one of possibly many different types of values.
@@ -198,6 +203,7 @@ public struct OpenAPIValueContainer: Codable, Hashable, Sendable {
             }
         }
     }
+    #endif
 
     // MARK: Equatable
 

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -78,6 +78,7 @@ final class Test_OpenAPIValue: Test_Runtime {
         try _testPrettyEncoded(container, expectedJSON: expectedString)
     }
 
+    #if canImport(CoreFoundation)
     func testEncodingNSNumber() throws {
         func assertEncodedCF(
             _ value: CFNumber,
@@ -128,6 +129,7 @@ final class Test_OpenAPIValue: Test_Runtime {
         XCTAssertThrowsError(try assertEncodedCF(kCFNumberNegativeInfinity, as: "-"))
         XCTAssertThrowsError(try assertEncodedCF(kCFNumberPositiveInfinity, as: "-"))
     }
+    #endif
     #endif
     func testEncoding_container_failure() throws {
         struct Foobar: Equatable {}


### PR DESCRIPTION
CoreFoundation isn't API on Windows, so compile it out in that case. All tests pass with these changes.