### PR TITLE
Switch integration tests to newer Swift test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,12 +23,30 @@ jobs:
       windows_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
+  construct-integration-test-matrix:
+    name: Construct integration matrix
+    runs-on: ubuntu-latest
+    outputs:
+      integration-test-matrix: '${{ steps.generate-matrix.outputs.integration-test-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "integration-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq
+          MATRIX_LINUX_COMMAND: ./scripts/run-integration-test.sh
+
   integration-test:
     name: Integration test
-    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    needs: construct-integration-test-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
       name: "Integration test"
-      matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && ./scripts/run-integration-test.sh"
+      matrix_string: '${{ needs.construct-integration-test-matrix.outputs.integration-test-matrix }}'
+      matrix_linux_nightly_main_enabled: false
 
   static-sdk:
     name: Static SDK

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,13 +27,30 @@ jobs:
       windows_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
+  construct-integration-test-matrix:
+    name: Construct integration matrix
+    runs-on: ubuntu-latest
+    outputs:
+      integration-test-matrix: '${{ steps.generate-matrix.outputs.integration-test-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "integration-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq && git config --global --add safe.directory /swift-openapi-runtime
+          MATRIX_LINUX_COMMAND: ./scripts/run-integration-test.sh
+          MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
+
   integration-test:
     name: Integration test
-    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    needs: construct-integration-test-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
       name: "Integration test"
-      matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && ./scripts/run-integration-test.sh"
-      matrix_linux_nightly_main_enabled: false
+      matrix_string: '${{ needs.construct-integration-test-matrix.outputs.integration-test-matrix }}'
 
   static-sdk:
     name: Static SDK


### PR DESCRIPTION
Switch integration tests to newer Swift test matrix

### Motivation:

To remove all uses of the older workflow so it can be removed to
simplify the workflows.

### Modifications:

* Switch integration tests to use the newer Swift test matrix workflow,
`swift_test_matrix.yml`
* As part of this I had to add a git config command to the setup
instructions. Lots of other repos have been using the matrix workflow
without needing this so I'm unsure of why it's needed here. If it
becomes common I'll look at a central way to include this.

### Result:

This should make no difference to the running of integration tests.