### PR TITLE
main.yml - add /swift-openapi-runtime as safe directory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       - id: generate-matrix
         run: echo "integration-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
         env:
-          MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq
+          MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq && git config --global --add safe.directory /swift-openapi-runtime
           MATRIX_LINUX_COMMAND: ./scripts/run-integration-test.sh
           MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
 


### PR DESCRIPTION
Add /swift-openapi-runtime as safe directory. This is already set in the pull request yaml but is missing here
