### PR TITLE
Fix typo in MultiError

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/ErrorExtensions.swift
+++ b/Sources/OpenAPIRuntime/Conversion/ErrorExtensions.swift
@@ -123,7 +123,7 @@ struct MultiError: Swift.Error, LocalizedError, CustomStringConvertible {
 
     var errorDescription: String? {
         if let first = errors.first {
-            return "Mutliple errors encountered, first one: \(first.localizedDescription)."
+            return "Multiple errors encountered, first one: \(first.localizedDescription)."
         } else {
             return "No errors"
         }


### PR DESCRIPTION
### Motivation

Don't have typos in error messages.

### Modifications

Fixed the typo.

### Result

Typo no more.

### Test Plan

N/A
