### PR TITLE
Enable release mode builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,5 +69,5 @@ jobs:
     with:
       windows_6_0_enabled: true
       windows_6_1_enabled: true
-      windows_nightly_6_1_enabled: true
+      windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,3 +66,8 @@ jobs:
   release-builds:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
+    with:
+      windows_6_0_enabled: true
+      windows_6_1_enabled: true
+      windows_nightly_6_1_enabled: true
+      windows_nightly_main_enabled: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,3 +62,7 @@ jobs:
     with:
       runner_pool: nightly
       build_scheme: swift-openapi-runtime
+
+  release-builds:
+    name: Release builds
+    uses: apple/swift-nio/.github/workflows/release_builds.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -70,3 +70,8 @@ jobs:
   release-builds:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
+    with:
+      windows_6_0_enabled: true
+      windows_6_1_enabled: true
+      windows_nightly_6_1_enabled: true
+      windows_nightly_main_enabled: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -66,3 +66,7 @@ jobs:
     with:
       runner_pool: general
       build_scheme: swift-openapi-runtime
+
+  release-builds:
+    name: Release builds
+    uses: apple/swift-nio/.github/workflows/release_builds.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -73,5 +73,5 @@ jobs:
     with:
       windows_6_0_enabled: true
       windows_6_1_enabled: true
-      windows_nightly_6_1_enabled: true
+      windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true


### PR DESCRIPTION
### Motivation:

Some errors do not show up in debug builds. Enabling release mode builds improves the CI coverage.

### Modifications:

Enable release mode builds for pull requests and scheduled builds on main.

### Result:

Improved CI coverage.