### PR TITLE
Fix encoding of OpenAPI{Object,Value}Container to allow multiple encodings in anyOf/allOf

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/CodableExtensions.swift
+++ b/Sources/OpenAPIRuntime/Conversion/CodableExtensions.swift
@@ -142,7 +142,7 @@
 }
 
 /// A freeform String coding key for decoding undocumented values.
-private struct StringKey: CodingKey, Hashable, Comparable {
+internal struct StringKey: CodingKey, Hashable, Comparable {
 
     var stringValue: String
     var intValue: Int? { Int(stringValue) }


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apple/swift-openapi-generator/issues/808.

More background: We used to use `singleValueContainer()`, provided by Codable, to encode not just primitive values, but also composite values like objects and arrays. This works in _most_ cases, but not when you have an `anyOf` (or an `allOf`), which contains more than 1 of these types (`OpenAPIValueContainer` or `OpenAPIObjectContainer`). When it hits that case, it crashes at runtime, because you can't encode multiple composite types into a single encoder using `singleValueContainer()`.

However, you can do that when using the proper `container(keyedBy:)` and `unkeyedContainer()` APIs, as that way you're not overwriting the value that's already there, but amending it.

### Modifications

Improve the encoding and decoding logic of `OpenAPIValueContainer` and `OpenAPIObjectContainer` to use the more appropriate Codable APIs when coding composite types, like objects and arrays.

### Result

Now we can have an anyOf/allOf with multiple of these types, and they encode/decode correctly. I also verified that the original example reported by the user works with this patch.

### Test Plan

Added more unit tests and ensured all still pass, also verified that Swift OpenAPI Generator's tests pass when pointed at this patched version of Runtime.
