### PR TITLE
Enable Swift 6.2 jobs in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,14 +15,17 @@ jobs:
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_2_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
       windows_6_0_enabled: true
       windows_6_1_enabled: true
+      windows_6_2_enabled: true
       windows_nightly_6_1_enabled: true
       windows_nightly_main_enabled: true
       windows_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       windows_6_1_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_6_2_arguments_override: "--explicit-target-dependency-import-check error"
       windows_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
@@ -69,5 +72,6 @@ jobs:
     with:
       windows_6_0_enabled: true
       windows_6_1_enabled: true
+      windows_6_2_enabled: true
       windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,14 +19,17 @@ jobs:
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_2_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
       windows_6_0_enabled: true
       windows_6_1_enabled: true
+      windows_6_2_enabled: true
       windows_nightly_6_1_enabled: true
       windows_nightly_main_enabled: true
       windows_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       windows_6_1_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_6_2_arguments_override: "--explicit-target-dependency-import-check error"
       windows_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
@@ -73,5 +76,6 @@ jobs:
     with:
       windows_6_0_enabled: true
       windows_6_1_enabled: true
+      windows_6_2_enabled: true
       windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true


### PR DESCRIPTION
Motivation:

Swift 6.2 has been released, we should add it to our CI coverage.

Modifications:

Add additional Swift 6.2 jobs where appropriate in main.yml, pull_request.yml

Result:

Improved test coverage.
