### PR TITLE
Fix formatting in swift-format 6.2

### DIFF
--- a/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
+++ b/Sources/OpenAPIRuntime/Interface/ErrorHandlingMiddleware.swift
@@ -52,7 +52,8 @@ public struct ErrorHandlingMiddleware: ServerMiddleware {
         body: OpenAPIRuntime.HTTPBody?,
         metadata: OpenAPIRuntime.ServerRequestMetadata,
         operationID: String,
-        next: @Sendable (HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata)
+        next:
+            @Sendable (HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata)
             async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?)
     ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
         do { return try await next(request, body, metadata) } catch {

--- a/Sources/OpenAPIRuntime/Interface/ServerTransport.swift
+++ b/Sources/OpenAPIRuntime/Interface/ServerTransport.swift
@@ -114,9 +114,10 @@ public protocol ServerTransport {
     /// - Important: The `path` can have mixed components, such
     ///   as `/file/{name}.zip`.
     func register(
-        _ handler: @Sendable @escaping (HTTPRequest, HTTPBody?, ServerRequestMetadata) async throws -> (
-            HTTPResponse, HTTPBody?
-        ),
+        _ handler:
+            @Sendable @escaping (HTTPRequest, HTTPBody?, ServerRequestMetadata) async throws -> (
+                HTTPResponse, HTTPBody?
+            ),
         method: HTTPRequest.Method,
         path: String
     ) throws

--- a/Sources/OpenAPIRuntime/Interface/UniversalServer.swift
+++ b/Sources/OpenAPIRuntime/Interface/UniversalServer.swift
@@ -91,8 +91,8 @@ import struct Foundation.URLComponents
         metadata: ServerRequestMetadata,
         forOperation operationID: String,
         using handlerMethod: @Sendable @escaping (APIHandler) -> ((OperationInput) async throws -> OperationOutput),
-        deserializer: @Sendable @escaping (HTTPRequest, HTTPBody?, ServerRequestMetadata) async throws ->
-            OperationInput,
+        deserializer:
+            @Sendable @escaping (HTTPRequest, HTTPBody?, ServerRequestMetadata) async throws -> OperationInput,
         serializer: @Sendable @escaping (OperationOutput, HTTPRequest) throws -> (HTTPResponse, HTTPBody?)
     ) async throws -> (HTTPResponse, HTTPBody?) where OperationInput: Sendable, OperationOutput: Sendable {
         @Sendable func wrappingErrors<R>(work: () async throws -> R, mapError: (any Error) -> any Error) async throws

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -454,7 +454,7 @@ struct MyAnyOf2<Value1: Codable & Hashable & Sendable, Value2: Codable & Hashabl
         self.value1 = value1
         self.value2 = value2
     }
-    public init(from decoder: any Decoder) throws {
+    init(from decoder: any Decoder) throws {
         var errors: [any Error] = []
         do { self.value1 = try .init(from: decoder) } catch { errors.append(error) }
         do { self.value2 = try .init(from: decoder) } catch { errors.append(error) }
@@ -465,7 +465,7 @@ struct MyAnyOf2<Value1: Codable & Hashable & Sendable, Value2: Codable & Hashabl
             errors: errors
         )
     }
-    public func encode(to encoder: any Encoder) throws {
+    func encode(to encoder: any Encoder) throws {
         try self.value1?.encode(to: encoder)
         try self.value2?.encode(to: encoder)
     }

--- a/Tests/OpenAPIRuntimeTests/Interface/Test_ErrorHandlingMiddleware.swift
+++ b/Tests/OpenAPIRuntimeTests/Interface/Test_ErrorHandlingMiddleware.swift
@@ -72,9 +72,10 @@ final class Test_ErrorHandlingMiddlewareTests: XCTestCase {
         XCTAssertEqual(responseBody, nil)
     }
 
-    private func getNextMiddleware(failurePhase: MockErrorMiddleware_Next.FailurePhase) -> @Sendable (
-        HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata
-    ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
+    private func getNextMiddleware(failurePhase: MockErrorMiddleware_Next.FailurePhase)
+        -> @Sendable (HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata)
+        async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?)
+    {
         let mockNext:
             @Sendable (HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata)
                 async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) = { request, body, metadata in

--- a/Tests/OpenAPIRuntimeTests/URICoder/Parsing/Test_URIParser.swift
+++ b/Tests/OpenAPIRuntimeTests/URICoder/Parsing/Test_URIParser.swift
@@ -524,11 +524,6 @@ final class Test_URIParser: Test_Runtime {
             }
             var result: ExpectedResult
 
-            init(string: String, result: ExpectedResult) {
-                self.string = string
-                self.result = result
-            }
-
             static func assert(_ string: String, equals value: RootType) -> Self {
                 .init(string: string, result: .success(value))
             }


### PR DESCRIPTION
### Motivation

Formatter got upgraded upstream, so we need to update formatting in our project.

### Modifications

Regenerated using swift-format from Swift 6.2 and made a few manual fixes.

### Result

Soundness format is clean again.

### Test Plan

Ran locally.
