### PR TITLE
Accept validation: allow +json structured syntax types

### DIFF
--- a/Sources/OpenAPIRuntime/Base/OpenAPIMIMEType.swift
+++ b/Sources/OpenAPIRuntime/Base/OpenAPIMIMEType.swift
@@ -210,10 +210,28 @@ extension OpenAPIMIMEType {
             guard receivedType.lowercased() == expectedType.lowercased() else { return .incompatible(.type) }
             return .subtypeWildcard
         case .concrete(let expectedType, let expectedSubtype):
-            guard
-                receivedType.lowercased() == expectedType.lowercased()
-                    && receivedSubtype.lowercased() == expectedSubtype.lowercased()
-            else { return .incompatible(.subtype) }
+            let receivedTypeLowercased = receivedType.lowercased()
+            let expectedTypeLowercased = expectedType.lowercased()
+            guard receivedTypeLowercased == expectedTypeLowercased else { return .incompatible(.type) }
+
+            let receivedSubtypeLowercased = receivedSubtype.lowercased()
+            let expectedSubtypeLowercased = expectedSubtype.lowercased()
+            let isExactSubtypeMatch = receivedSubtypeLowercased == expectedSubtypeLowercased
+            if !isExactSubtypeMatch {
+                let isStructuredSyntaxSuffixMatch =
+                    Self.structuredSyntaxSuffix(of: receivedSubtypeLowercased) == expectedSubtypeLowercased
+                let isStructuredSyntaxWildcardMatch: Bool
+                if let structuredSyntaxWildcardSuffix = Self.structuredSyntaxWildcardSuffix(of: expectedSubtypeLowercased) {
+                    isStructuredSyntaxWildcardMatch =
+                        receivedSubtypeLowercased == structuredSyntaxWildcardSuffix
+                        || Self.structuredSyntaxSuffix(of: receivedSubtypeLowercased) == structuredSyntaxWildcardSuffix
+                } else {
+                    isStructuredSyntaxWildcardMatch = false
+                }
+                guard isStructuredSyntaxSuffixMatch || isStructuredSyntaxWildcardMatch else {
+                    return .incompatible(.subtype)
+                }
+            }
 
             // A full concrete match, so also check parameters.
             // The rule is:
@@ -243,5 +261,23 @@ extension OpenAPIMIMEType {
             }
             return .typeAndSubtype(matchedParameterCount: matchedParameterCount)
         }
+    }
+
+    /// Returns the structured syntax suffix component of a subtype, if present.
+    /// For example, returns `"json"` for `"problem+json"`.
+    static func structuredSyntaxSuffix(of subtype: String) -> String? {
+        guard let plusIndex = subtype.lastIndex(of: "+") else { return nil }
+        let suffixStart = subtype.index(after: plusIndex)
+        guard suffixStart < subtype.endIndex else { return nil }
+        return String(subtype[suffixStart...])
+    }
+
+    /// Returns the structured syntax suffix of a wildcard subtype, if present.
+    /// For example, returns `"json"` for `"*+json"`.
+    static func structuredSyntaxWildcardSuffix(of subtype: String) -> String? {
+        guard subtype.hasPrefix("*+") else { return nil }
+        let suffixStart = subtype.index(subtype.startIndex, offsetBy: 2)
+        guard suffixStart < subtype.endIndex else { return nil }
+        return String(subtype[suffixStart...])
     }
 }

--- a/Sources/OpenAPIRuntime/Base/OpenAPIMIMEType.swift
+++ b/Sources/OpenAPIRuntime/Base/OpenAPIMIMEType.swift
@@ -216,21 +216,8 @@ extension OpenAPIMIMEType {
 
             let receivedSubtypeLowercased = receivedSubtype.lowercased()
             let expectedSubtypeLowercased = expectedSubtype.lowercased()
-            let isExactSubtypeMatch = receivedSubtypeLowercased == expectedSubtypeLowercased
-            if !isExactSubtypeMatch {
-                let isStructuredSyntaxSuffixMatch =
-                    Self.structuredSyntaxSuffix(of: receivedSubtypeLowercased) == expectedSubtypeLowercased
-                let isStructuredSyntaxWildcardMatch: Bool
-                if let structuredSyntaxWildcardSuffix = Self.structuredSyntaxWildcardSuffix(of: expectedSubtypeLowercased) {
-                    isStructuredSyntaxWildcardMatch =
-                        receivedSubtypeLowercased == structuredSyntaxWildcardSuffix
-                        || Self.structuredSyntaxSuffix(of: receivedSubtypeLowercased) == structuredSyntaxWildcardSuffix
-                } else {
-                    isStructuredSyntaxWildcardMatch = false
-                }
-                guard isStructuredSyntaxSuffixMatch || isStructuredSyntaxWildcardMatch else {
-                    return .incompatible(.subtype)
-                }
+            guard Self.subtypesMatch(receivedSubtypeLowercased, expectedSubtypeLowercased) else {
+                return .incompatible(.subtype)
             }
 
             // A full concrete match, so also check parameters.
@@ -279,5 +266,26 @@ extension OpenAPIMIMEType {
         let suffixStart = subtype.index(subtype.startIndex, offsetBy: 2)
         guard suffixStart < subtype.endIndex else { return nil }
         return String(subtype[suffixStart...])
+    }
+
+    /// Returns whether two lowercased subtypes are compatible.
+    /// Supports exact matches, same-type structured syntax suffix matches
+    /// in either direction, and wildcard structured syntax suffixes.
+    static func subtypesMatch(_ lhs: String, _ rhs: String) -> Bool {
+        if lhs == rhs { return true }
+
+        if let lhsStructuredSyntaxWildcardSuffix = Self.structuredSyntaxWildcardSuffix(of: lhs) {
+            return rhs == lhsStructuredSyntaxWildcardSuffix
+                || Self.structuredSyntaxSuffix(of: rhs) == lhsStructuredSyntaxWildcardSuffix
+        }
+        if let rhsStructuredSyntaxWildcardSuffix = Self.structuredSyntaxWildcardSuffix(of: rhs) {
+            return lhs == rhsStructuredSyntaxWildcardSuffix
+                || Self.structuredSyntaxSuffix(of: lhs) == rhsStructuredSyntaxWildcardSuffix
+        }
+
+        let lhsStructuredSyntaxSuffix = Self.structuredSyntaxSuffix(of: lhs)
+        let rhsStructuredSyntaxSuffix = Self.structuredSyntaxSuffix(of: rhs)
+        return lhsStructuredSyntaxSuffix == rhs || rhsStructuredSyntaxSuffix == lhs
+            || (lhsStructuredSyntaxSuffix != nil && lhsStructuredSyntaxSuffix == rhsStructuredSyntaxSuffix)
     }
 }

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
@@ -509,30 +509,16 @@ fileprivate extension OpenAPIMIMEType {
             if acceptSubtypeLowercased == substringSubtypeLowercased { return true }
 
             // RFC 6839 structured syntax suffix matching (e.g. application/problem+json).
-            if let structuredSyntaxSuffix = structuredSyntaxSuffix(of: substringSubtypeLowercased),
+            if let structuredSyntaxSuffix = Self.structuredSyntaxSuffix(of: substringSubtypeLowercased),
                 structuredSyntaxSuffix == acceptSubtypeLowercased
             { return true }
 
             // Accept: application/*+json matching (and treating it as also matching application/json).
-            if let structuredSyntaxWildcardSuffix = structuredSyntaxWildcardSuffix(of: acceptSubtypeLowercased) {
+            if let structuredSyntaxWildcardSuffix = Self.structuredSyntaxWildcardSuffix(of: acceptSubtypeLowercased) {
                 return substringSubtypeLowercased == structuredSyntaxWildcardSuffix
-                    || structuredSyntaxSuffix(of: substringSubtypeLowercased) == structuredSyntaxWildcardSuffix
+                    || Self.structuredSyntaxSuffix(of: substringSubtypeLowercased) == structuredSyntaxWildcardSuffix
             }
             return false
         }
-    }
-
-    private func structuredSyntaxSuffix(of subtype: String) -> String? {
-        guard let plusIndex = subtype.lastIndex(of: "+") else { return nil }
-        let suffixStart = subtype.index(after: plusIndex)
-        guard suffixStart < subtype.endIndex else { return nil }
-        return String(subtype[suffixStart...])
-    }
-
-    private func structuredSyntaxWildcardSuffix(of acceptSubtype: String) -> String? {
-        guard acceptSubtype.hasPrefix("*+") else { return nil }
-        let suffixStart = acceptSubtype.index(acceptSubtype.startIndex, offsetBy: 2)
-        guard suffixStart < acceptSubtype.endIndex else { return nil }
-        return String(acceptSubtype[suffixStart...])
     }
 }

--- a/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
@@ -504,21 +504,7 @@ fileprivate extension OpenAPIMIMEType {
 
             let acceptSubtypeLowercased = acceptSubtype.lowercased()
             let substringSubtypeLowercased = substringSubtype.lowercased()
-
-            // Exact match.
-            if acceptSubtypeLowercased == substringSubtypeLowercased { return true }
-
-            // RFC 6839 structured syntax suffix matching (e.g. application/problem+json).
-            if let structuredSyntaxSuffix = Self.structuredSyntaxSuffix(of: substringSubtypeLowercased),
-                structuredSyntaxSuffix == acceptSubtypeLowercased
-            { return true }
-
-            // Accept: application/*+json matching (and treating it as also matching application/json).
-            if let structuredSyntaxWildcardSuffix = Self.structuredSyntaxWildcardSuffix(of: acceptSubtypeLowercased) {
-                return substringSubtypeLowercased == structuredSyntaxWildcardSuffix
-                    || Self.structuredSyntaxSuffix(of: substringSubtypeLowercased) == structuredSyntaxWildcardSuffix
-            }
-            return false
+            return Self.subtypesMatch(acceptSubtypeLowercased, substringSubtypeLowercased)
         }
     }
 }

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIMIMEType.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIMIMEType.swift
@@ -103,6 +103,7 @@ final class Test_OpenAPIMIMEType: Test_Runtime {
         let jsonWith2Params = OpenAPIMIMEType("application/json; charset=utf-8; version=1")!
         let jsonWith1Param = OpenAPIMIMEType("application/json; charset=utf-8")!
         let json = OpenAPIMIMEType("application/json")!
+        let anyJsonStructuredSyntax = OpenAPIMIMEType("application/*+json")!
         let fullWildcard = OpenAPIMIMEType("*/*")!
         let subtypeWildcard = OpenAPIMIMEType("application/*")!
 
@@ -130,5 +131,34 @@ final class Test_OpenAPIMIMEType: Test_Runtime {
         testJSONWith2Params(against: json, expected: .typeAndSubtype(matchedParameterCount: 0))
         testJSONWith2Params(against: subtypeWildcard, expected: .subtypeWildcard)
         testJSONWith2Params(against: fullWildcard, expected: .wildcard)
+
+        testCase(
+            receivedType: "application",
+            receivedSubtype: "problem+json",
+            receivedParameters: [:],
+            against: json,
+            expected: .typeAndSubtype(matchedParameterCount: 0)
+        )
+        testCase(
+            receivedType: "application",
+            receivedSubtype: "json",
+            receivedParameters: [:],
+            against: anyJsonStructuredSyntax,
+            expected: .typeAndSubtype(matchedParameterCount: 0)
+        )
+        testCase(
+            receivedType: "application",
+            receivedSubtype: "problem+json",
+            receivedParameters: [:],
+            against: anyJsonStructuredSyntax,
+            expected: .typeAndSubtype(matchedParameterCount: 0)
+        )
+        testCase(
+            receivedType: "application",
+            receivedSubtype: "problem+xml",
+            receivedParameters: [:],
+            against: json,
+            expected: .incompatible(.subtype)
+        )
     }
 }

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIMIMEType.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIMIMEType.swift
@@ -103,6 +103,7 @@ final class Test_OpenAPIMIMEType: Test_Runtime {
         let jsonWith2Params = OpenAPIMIMEType("application/json; charset=utf-8; version=1")!
         let jsonWith1Param = OpenAPIMIMEType("application/json; charset=utf-8")!
         let json = OpenAPIMIMEType("application/json")!
+        let problemJSON = OpenAPIMIMEType("application/problem+json")!
         let anyJsonStructuredSyntax = OpenAPIMIMEType("application/*+json")!
         let fullWildcard = OpenAPIMIMEType("*/*")!
         let subtypeWildcard = OpenAPIMIMEType("application/*")!
@@ -143,6 +144,13 @@ final class Test_OpenAPIMIMEType: Test_Runtime {
             receivedType: "application",
             receivedSubtype: "json",
             receivedParameters: [:],
+            against: problemJSON,
+            expected: .typeAndSubtype(matchedParameterCount: 0)
+        )
+        testCase(
+            receivedType: "application",
+            receivedSubtype: "json",
+            receivedParameters: [:],
             against: anyJsonStructuredSyntax,
             expected: .typeAndSubtype(matchedParameterCount: 0)
         )
@@ -159,6 +167,13 @@ final class Test_OpenAPIMIMEType: Test_Runtime {
             receivedParameters: [:],
             against: json,
             expected: .incompatible(.subtype)
+        )
+        testCase(
+            receivedType: "text",
+            receivedSubtype: "foo+json",
+            receivedParameters: [:],
+            against: json,
+            expected: .incompatible(.type)
         )
     }
 }

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
@@ -82,6 +82,17 @@ final class Test_CommonConverterExtensions: Test_Runtime {
         try testCase(received: "application/json; charset=utf-8; version=1", options: ["*/*"], expected: "*/*")
 
         try testCase(received: "image/png", options: ["image/*", "*/*"], expected: "image/*")
+        try testCase(received: "application/problem+json", options: ["application/json"], expected: "application/json")
+        try testCase(
+            received: "application/problem+json",
+            options: ["application/json", "application/problem+json"],
+            expected: "application/problem+json"
+        )
+        try testCase(
+            received: "application/problem+json; charset=utf-8; version=1",
+            options: ["application/json", "application/json; charset=utf-8"],
+            expected: "application/json; charset=utf-8"
+        )
         XCTAssertThrowsError(
             try testCase(received: "text/csv", options: ["text/html", "application/json"], expected: "-")
         ) { error in
@@ -104,6 +115,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
         }
         try testCase(received: nil, match: "application/json")
         try testCase(received: "application/json", match: "application/json")
+        try testCase(received: "application/problem+json", match: "application/json")
         try testCase(received: "application/json", match: "application/*")
         try testCase(received: "application/json", match: "*/*")
     }

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Common.swift
@@ -83,6 +83,7 @@ final class Test_CommonConverterExtensions: Test_Runtime {
 
         try testCase(received: "image/png", options: ["image/*", "*/*"], expected: "image/*")
         try testCase(received: "application/problem+json", options: ["application/json"], expected: "application/json")
+        try testCase(received: "application/json", options: ["application/problem+json"], expected: "application/problem+json")
         try testCase(
             received: "application/problem+json",
             options: ["application/json", "application/problem+json"],
@@ -116,8 +117,10 @@ final class Test_CommonConverterExtensions: Test_Runtime {
         try testCase(received: nil, match: "application/json")
         try testCase(received: "application/json", match: "application/json")
         try testCase(received: "application/problem+json", match: "application/json")
+        try testCase(received: "application/json", match: "application/problem+json")
         try testCase(received: "application/json", match: "application/*")
         try testCase(received: "application/json", match: "*/*")
+        XCTAssertThrowsError(try testCase(received: "text/foo+json", match: "application/json"))
     }
 
     func testExtractContentDispositionNameAndFilename() throws {

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
@@ -35,6 +35,8 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         let wildcard: HTTPFields = [.accept: "*/*"]
         let partialWildcard: HTTPFields = [.accept: "text/*"]
         let short: HTTPFields = [.accept: "text/plain"]
+        let json: HTTPFields = [.accept: "application/json"]
+        let anyJsonStructuredSyntax: HTTPFields = [.accept: "application/*+json"]
         let long: HTTPFields = [
             .accept: "text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, */*;q=0.8"
         ]
@@ -53,6 +55,11 @@ final class Test_ServerConverterExtensions: Test_Runtime {
             // Accept: text/plain, text/plain succeeds, application/json fails
             (short, "text/plain", true), (short, "application/json", false), (short, "application/*", false),
             (short, "*/*", false),
+
+            // RFC 6839 structured syntax suffix matching (common with RFC 7807 Problem Details):
+            // If response is application/problem+json, treat Accept: application/json as compatible.
+            (json, "application/problem+json", true),
+            (anyJsonStructuredSyntax, "application/problem+json", true),
 
             // A bunch of acceptable content types
             (long, "text/html", true), (long, "application/xhtml+xml", true), (long, "application/xml", true),

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
@@ -59,7 +59,10 @@ final class Test_ServerConverterExtensions: Test_Runtime {
             // RFC 6839 structured syntax suffix matching (common with RFC 7807 Problem Details):
             // If response is application/problem+json, treat Accept: application/json as compatible.
             (json, "application/problem+json", true),
+            (json, "application/json", true),
+            (anyJsonStructuredSyntax, "application/json", true),
             (anyJsonStructuredSyntax, "application/problem+json", true),
+            (json, "text/foo+json", false),
 
             // A bunch of acceptable content types
             (long, "text/html", true), (long, "application/xhtml+xml", true), (long, "application/xml", true),


### PR DESCRIPTION
### Motivation

`Converter.validateAcceptIfPresent` validates the request `Accept` header against the server’s chosen response `Content-Type`. Today this is strict (exact `type/subtype` match, `type/*`, or `*/*`), which means a common real-world pairing fails:

- Request: `Accept: application/json`
- Error response (RFC 7807 Problem Details): `Content-Type: application/problem+json`

HTTP content negotiation does not standardize suffix-aware matching for structured syntax suffixes, so treating `application/json` as compatible with `application/*+json` is a server policy choice. However, it is widely expected in practice (especially around Problem Details), and the strict behavior forces downstream servers to add middleware workarounds (e.g. mutate `Accept` or avoid emitting `application/problem+json`) just to prevent a runtime error.

### Modifications

- Extend `OpenAPIMIMEType.satisfies(acceptValue:)` to add an additional compatibility rule for structured syntax suffixes:
  - Treat `Accept: application/json` as compatible with `Content-Type: application/problem+json` (and other `application/*+json` types with `+json`).
  - Treat `Accept: application/*+json` as compatible with `application/problem+json` (and also `application/json`).
- Add focused unit coverage in `Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift` under `testValidateAccept`.

### Result

The runtime’s `Accept` validation no longer throws for common JSON-based structured media types like `application/problem+json` when clients send `Accept: application/json`, reducing downstream middleware/workarounds while keeping existing exact and wildcard matching behavior.

### Test Plan

- `swift test --filter Test_ServerConverterExtensions.testValidateAccept`
