### PR TITLE
Add `OpenAPIFetchRuntime` for Web APIs via JS interop

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,20 +24,26 @@ let swiftSettings: [SwiftSetting] = [
 let package = Package(
     name: "swift-openapi-runtime",
     platforms: [
-        .macOS(.v10_15), .macCatalyst(.v13), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .visionOS(.v1)
+        .macOS(.v13), .macCatalyst(.v13), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .visionOS(.v1)
     ],
     products: [
         .library(
             name: "OpenAPIRuntime",
             targets: ["OpenAPIRuntime"]
+        ),
+        .library(
+            name: "OpenAPIFetchRuntime",
+            targets: ["OpenAPIFetchRuntime"]
         )
     ],
     traits: [
         .trait(name: "FullFoundation"),
+        .trait(name: "JavaScriptFetch"),
         .default(enabledTraits: ["FullFoundation"])
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-http-types", from: "1.0.0"),
+        .package(url: "https://github.com/swiftwasm/JavaScriptKit", from: "0.49.0"),
     ],
     targets: [
         .target(
@@ -51,6 +57,19 @@ let package = Package(
             name: "OpenAPIRuntimeTests",
             dependencies: ["OpenAPIRuntime"],
             swiftSettings: swiftSettings
+        ),
+        .target(
+            name: "OpenAPIFetchRuntime",
+            dependencies: [
+                .product(
+                    name: "JavaScriptKit",
+                    package: "JavaScriptKit",
+                    condition: .when(traits: ["JavaScriptFetch"])
+                ),
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("Extern"),
+            ]
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-http-types", from: "1.0.0"),
-        .package(url: "https://github.com/swiftwasm/JavaScriptKit", from: "0.49.0"),
+        .package(url: "https://github.com/swiftwasm/JavaScriptKit", .upToNextMinor(from: "0.50.2")),
     ],
     targets: [
         .target(

--- a/Sources/OpenAPIFetchRuntime/BridgeJS.swift
+++ b/Sources/OpenAPIFetchRuntime/BridgeJS.swift
@@ -1,0 +1,700 @@
+#if JavaScriptFetch
+// bridge-js: skip
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+@_spi(BridgeJS) public import JavaScriptKit
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes7JSValueV_y")
+fileprivate func invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes7JSValueV_y_extern(_ callback: Int32, _ param0Kind: Int32, _ param0Payload1: Int32, _ param0Payload2: Float64) -> Void
+#else
+fileprivate func invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes7JSValueV_y_extern(_ callback: Int32, _ param0Kind: Int32, _ param0Payload1: Int32, _ param0Payload2: Float64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes7JSValueV_y(_ callback: Int32, _ param0Kind: Int32, _ param0Payload1: Int32, _ param0Payload2: Float64) -> Void {
+    return invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes7JSValueV_y_extern(callback, param0Kind, param0Payload1, param0Payload2)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes7JSValueV_y")
+fileprivate func make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes7JSValueV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes7JSValueV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes7JSValueV_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes7JSValueV_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_19OpenAPIFetchRuntimes7JSValueV_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending JSValue) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let (param0Kind, param0Payload1, param0Payload2) = param0.bridgeJSLowerParameter()
+            invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes7JSValueV_y(callbackValue, param0Kind, param0Payload1, param0Payload2)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending JSValue) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending JSValue) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes7JSValueV_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes7JSValueV_y")
+@_cdecl("invoke_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes7JSValueV_y")
+public func _invoke_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes7JSValueV_y(_ boxPtr: UnsafeMutableRawPointer, _ param0Kind: Int32, _ param0Payload1: Int32, _ param0Payload2: Float64) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending JSValue) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(JSValue.bridgeJSLiftParameter(param0Kind, param0Payload1, param0Payload2))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes8ResponseC_y")
+fileprivate func invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes8ResponseC_y_extern(_ callback: Int32, _ param0: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes8ResponseC_y_extern(_ callback: Int32, _ param0: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes8ResponseC_y(_ callback: Int32, _ param0: Int32) -> Void {
+    return invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes8ResponseC_y_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes8ResponseC_y")
+fileprivate func make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes8ResponseC_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes8ResponseC_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes8ResponseC_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes8ResponseC_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_19OpenAPIFetchRuntimes8ResponseC_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending Response) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0Value = param0.bridgeJSLowerParameter()
+            invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes8ResponseC_y(callbackValue, param0Value)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending Response) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending Response) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes8ResponseC_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes8ResponseC_y")
+@_cdecl("invoke_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes8ResponseC_y")
+public func _invoke_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimes8ResponseC_y(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending Response) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(Response.bridgeJSLiftParameter(param0))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimesSS_y")
+fileprivate func invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimesSS_y_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimesSS_y_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimesSS_y(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    return invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimesSS_y_extern(callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimesSS_y")
+fileprivate func make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimesSS_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimesSS_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimesSS_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimesSS_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_19OpenAPIFetchRuntimesSS_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending String) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                invoke_js_callback_OpenAPIFetchRuntime_19OpenAPIFetchRuntimesSS_y(callbackValue, param0Bytes, param0Length)
+            }
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending String) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending String) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimesSS_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimesSS_y")
+@_cdecl("invoke_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimesSS_y")
+public func _invoke_swift_closure_OpenAPIFetchRuntime_19OpenAPIFetchRuntimesSS_y(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending String) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_fetch")
+fileprivate func bjs_fetch_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ inputBytes: Int32, _ inputLength: Int32, _ options: Int32) -> Void
+#else
+fileprivate func bjs_fetch_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ inputBytes: Int32, _ inputLength: Int32, _ options: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_fetch(_ resolveRef: Int32, _ rejectRef: Int32, _ inputBytes: Int32, _ inputLength: Int32, _ options: Int32) -> Void {
+    return bjs_fetch_extern(resolveRef, rejectRef, inputBytes, inputLength, options)
+}
+
+func _$fetch(_ input: String, _ options: RequestInit) async throws(JSException) -> Response {
+    let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
+            JSTypedClosure<(sending Response) -> Void>($0)
+        }, makeRejectClosure: {
+            JSTypedClosure<(sending JSValue) -> Void>($0)
+        }) { resolveRef, rejectRef in
+        input.bridgeJSWithLoweredParameter { (inputBytes, inputLength) in
+            let optionsValue = options.bridgeJSLowerParameter()
+            bjs_fetch(resolveRef, rejectRef, inputBytes, inputLength, optionsValue)
+        }
+    }
+    return resolved
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_encodeURIComponent")
+fileprivate func bjs_encodeURIComponent_extern(_ stringBytes: Int32, _ stringLength: Int32) -> Int32
+#else
+fileprivate func bjs_encodeURIComponent_extern(_ stringBytes: Int32, _ stringLength: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_encodeURIComponent(_ stringBytes: Int32, _ stringLength: Int32) -> Int32 {
+    return bjs_encodeURIComponent_extern(stringBytes, stringLength)
+}
+
+func _$encodeURIComponent(_ string: String) throws(JSException) -> String {
+    let ret0 = string.bridgeJSWithLoweredParameter { (stringBytes, stringLength) in
+        let ret = bjs_encodeURIComponent(stringBytes, stringLength)
+        return ret
+    }
+    let ret = ret0
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return String.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_Headers_init")
+fileprivate func bjs_Headers_init_extern() -> Int32
+#else
+fileprivate func bjs_Headers_init_extern() -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_Headers_init() -> Int32 {
+    return bjs_Headers_init_extern()
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_Headers_append")
+fileprivate func bjs_Headers_append_extern(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+#else
+fileprivate func bjs_Headers_append_extern(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_Headers_append(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return bjs_Headers_append_extern(self, nameBytes, nameLength, valueBytes, valueLength)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_Headers_delete")
+fileprivate func bjs_Headers_delete_extern(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void
+#else
+fileprivate func bjs_Headers_delete_extern(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_Headers_delete(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+    return bjs_Headers_delete_extern(self, nameBytes, nameLength)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_Headers_get")
+fileprivate func bjs_Headers_get_extern(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void
+#else
+fileprivate func bjs_Headers_get_extern(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_Headers_get(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+    return bjs_Headers_get_extern(self, nameBytes, nameLength)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_Headers_has")
+fileprivate func bjs_Headers_has_extern(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Int32
+#else
+fileprivate func bjs_Headers_has_extern(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_Headers_has(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Int32 {
+    return bjs_Headers_has_extern(self, nameBytes, nameLength)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_Headers_set")
+fileprivate func bjs_Headers_set_extern(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+#else
+fileprivate func bjs_Headers_set_extern(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_Headers_set(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return bjs_Headers_set_extern(self, nameBytes, nameLength, valueBytes, valueLength)
+}
+
+func _$Headers_init() throws(JSException) -> JSObject {
+    let ret = bjs_Headers_init()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSObject.bridgeJSLiftReturn(ret)
+}
+
+func _$Headers_append(_ self: JSObject, _ name: String, _ value: String) throws(JSException) -> Void {
+    let selfValue = self.bridgeJSLowerParameter()
+    name.bridgeJSWithLoweredParameter { (nameBytes, nameLength) in
+        value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+            bjs_Headers_append(selfValue, nameBytes, nameLength, valueBytes, valueLength)
+        }
+    }
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+func _$Headers_delete(_ self: JSObject, _ name: String) throws(JSException) -> Void {
+    let selfValue = self.bridgeJSLowerParameter()
+    name.bridgeJSWithLoweredParameter { (nameBytes, nameLength) in
+        bjs_Headers_delete(selfValue, nameBytes, nameLength)
+    }
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+func _$Headers_get(_ self: JSObject, _ name: String) throws(JSException) -> Optional<String> {
+    let selfValue = self.bridgeJSLowerParameter()
+    name.bridgeJSWithLoweredParameter { (nameBytes, nameLength) in
+        bjs_Headers_get(selfValue, nameBytes, nameLength)
+    }
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Optional<String>.bridgeJSLiftReturnFromSideChannel()
+}
+
+func _$Headers_has(_ self: JSObject, _ name: String) throws(JSException) -> Bool {
+    let selfValue = self.bridgeJSLowerParameter()
+    let ret0 = name.bridgeJSWithLoweredParameter { (nameBytes, nameLength) in
+        let ret = bjs_Headers_has(selfValue, nameBytes, nameLength)
+        return ret
+    }
+    let ret = ret0
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Bool.bridgeJSLiftReturn(ret)
+}
+
+func _$Headers_set(_ self: JSObject, _ name: String, _ value: String) throws(JSException) -> Void {
+    let selfValue = self.bridgeJSLowerParameter()
+    name.bridgeJSWithLoweredParameter { (nameBytes, nameLength) in
+        value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+            bjs_Headers_set(selfValue, nameBytes, nameLength, valueBytes, valueLength)
+        }
+    }
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_Response_headers_get")
+fileprivate func bjs_Response_headers_get_extern(_ self: Int32) -> Int32
+#else
+fileprivate func bjs_Response_headers_get_extern(_ self: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_Response_headers_get(_ self: Int32) -> Int32 {
+    return bjs_Response_headers_get_extern(self)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_Response_ok_get")
+fileprivate func bjs_Response_ok_get_extern(_ self: Int32) -> Int32
+#else
+fileprivate func bjs_Response_ok_get_extern(_ self: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_Response_ok_get(_ self: Int32) -> Int32 {
+    return bjs_Response_ok_get_extern(self)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_Response_status_get")
+fileprivate func bjs_Response_status_get_extern(_ self: Int32) -> Float64
+#else
+fileprivate func bjs_Response_status_get_extern(_ self: Int32) -> Float64 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_Response_status_get(_ self: Int32) -> Float64 {
+    return bjs_Response_status_get_extern(self)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_Response_statusText_get")
+fileprivate func bjs_Response_statusText_get_extern(_ self: Int32) -> Int32
+#else
+fileprivate func bjs_Response_statusText_get_extern(_ self: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_Response_statusText_get(_ self: Int32) -> Int32 {
+    return bjs_Response_statusText_get_extern(self)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_Response_url_get")
+fileprivate func bjs_Response_url_get_extern(_ self: Int32) -> Int32
+#else
+fileprivate func bjs_Response_url_get_extern(_ self: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_Response_url_get(_ self: Int32) -> Int32 {
+    return bjs_Response_url_get_extern(self)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_Response_json")
+fileprivate func bjs_Response_json_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ self: Int32) -> Void
+#else
+fileprivate func bjs_Response_json_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ self: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_Response_json(_ resolveRef: Int32, _ rejectRef: Int32, _ self: Int32) -> Void {
+    return bjs_Response_json_extern(resolveRef, rejectRef, self)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_Response_text")
+fileprivate func bjs_Response_text_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ self: Int32) -> Void
+#else
+fileprivate func bjs_Response_text_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ self: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_Response_text(_ resolveRef: Int32, _ rejectRef: Int32, _ self: Int32) -> Void {
+    return bjs_Response_text_extern(resolveRef, rejectRef, self)
+}
+
+func _$Response_headers_get(_ self: JSObject) throws(JSException) -> Headers {
+    let selfValue = self.bridgeJSLowerParameter()
+    let ret = bjs_Response_headers_get(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Headers.bridgeJSLiftReturn(ret)
+}
+
+func _$Response_ok_get(_ self: JSObject) throws(JSException) -> Bool {
+    let selfValue = self.bridgeJSLowerParameter()
+    let ret = bjs_Response_ok_get(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Bool.bridgeJSLiftReturn(ret)
+}
+
+func _$Response_status_get(_ self: JSObject) throws(JSException) -> Double {
+    let selfValue = self.bridgeJSLowerParameter()
+    let ret = bjs_Response_status_get(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return Double.bridgeJSLiftReturn(ret)
+}
+
+func _$Response_statusText_get(_ self: JSObject) throws(JSException) -> String {
+    let selfValue = self.bridgeJSLowerParameter()
+    let ret = bjs_Response_statusText_get(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return String.bridgeJSLiftReturn(ret)
+}
+
+func _$Response_url_get(_ self: JSObject) throws(JSException) -> String {
+    let selfValue = self.bridgeJSLowerParameter()
+    let ret = bjs_Response_url_get(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return String.bridgeJSLiftReturn(ret)
+}
+
+func _$Response_json(_ self: JSObject) async throws(JSException) -> JSValue {
+    let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
+            JSTypedClosure<(sending JSValue) -> Void>($0)
+        }, makeRejectClosure: {
+            JSTypedClosure<(sending JSValue) -> Void>($0)
+        }) { resolveRef, rejectRef in
+        let selfValue = self.bridgeJSLowerParameter()
+        bjs_Response_json(resolveRef, rejectRef, selfValue)
+    }
+    return resolved
+}
+
+func _$Response_text(_ self: JSObject) async throws(JSException) -> String {
+    let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
+            JSTypedClosure<(sending String) -> Void>($0)
+        }, makeRejectClosure: {
+            JSTypedClosure<(sending JSValue) -> Void>($0)
+        }) { resolveRef, rejectRef in
+        let selfValue = self.bridgeJSLowerParameter()
+        bjs_Response_text(resolveRef, rejectRef, selfValue)
+    }
+    return resolved
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_RequestInit_init")
+fileprivate func bjs_RequestInit_init_extern(_ methodBytes: Int32, _ methodLength: Int32, _ headers: Int32, _ bodyIsSome: Int32, _ bodyValue: Int32) -> Int32
+#else
+fileprivate func bjs_RequestInit_init_extern(_ methodBytes: Int32, _ methodLength: Int32, _ headers: Int32, _ bodyIsSome: Int32, _ bodyValue: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_RequestInit_init(_ methodBytes: Int32, _ methodLength: Int32, _ headers: Int32, _ bodyIsSome: Int32, _ bodyValue: Int32) -> Int32 {
+    return bjs_RequestInit_init_extern(methodBytes, methodLength, headers, bodyIsSome, bodyValue)
+}
+
+func _$RequestInit_init(_ method: HTTPMethod, _ headers: Headers, _ body: Optional<JSObject>) throws(JSException) -> JSObject {
+    let ret0 = method.bridgeJSWithLoweredParameter { (methodBytes, methodLength) in
+        let headersValue = headers.bridgeJSLowerParameter()
+        let (bodyIsSome, bodyValue) = body.bridgeJSLowerParameter()
+        let ret = bjs_RequestInit_init(methodBytes, methodLength, headersValue, bodyIsSome, bodyValue)
+        return ret
+    }
+    let ret = ret0
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSObject.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_URL_init")
+fileprivate func bjs_URL_init_extern(_ pathBytes: Int32, _ pathLength: Int32, _ baseBytes: Int32, _ baseLength: Int32) -> Int32
+#else
+fileprivate func bjs_URL_init_extern(_ pathBytes: Int32, _ pathLength: Int32, _ baseBytes: Int32, _ baseLength: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_URL_init(_ pathBytes: Int32, _ pathLength: Int32, _ baseBytes: Int32, _ baseLength: Int32) -> Int32 {
+    return bjs_URL_init_extern(pathBytes, pathLength, baseBytes, baseLength)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_URL_href_get")
+fileprivate func bjs_URL_href_get_extern(_ self: Int32) -> Int32
+#else
+fileprivate func bjs_URL_href_get_extern(_ self: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_URL_href_get(_ self: Int32) -> Int32 {
+    return bjs_URL_href_get_extern(self)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_URL_searchParams_get")
+fileprivate func bjs_URL_searchParams_get_extern(_ self: Int32) -> Int32
+#else
+fileprivate func bjs_URL_searchParams_get_extern(_ self: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_URL_searchParams_get(_ self: Int32) -> Int32 {
+    return bjs_URL_searchParams_get_extern(self)
+}
+
+func _$URL_init(_ path: String, _ base: String) throws(JSException) -> JSObject {
+    let ret0 = path.bridgeJSWithLoweredParameter { (pathBytes, pathLength) in
+        let ret1 = base.bridgeJSWithLoweredParameter { (baseBytes, baseLength) in
+            let ret = bjs_URL_init(pathBytes, pathLength, baseBytes, baseLength)
+            return ret
+        }
+        return ret1
+    }
+    let ret = ret0
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return JSObject.bridgeJSLiftReturn(ret)
+}
+
+func _$URL_href_get(_ self: JSObject) throws(JSException) -> String {
+    let selfValue = self.bridgeJSLowerParameter()
+    let ret = bjs_URL_href_get(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return String.bridgeJSLiftReturn(ret)
+}
+
+func _$URL_searchParams_get(_ self: JSObject) throws(JSException) -> URLSearchParams {
+    let selfValue = self.bridgeJSLowerParameter()
+    let ret = bjs_URL_searchParams_get(selfValue)
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+    return URLSearchParams.bridgeJSLiftReturn(ret)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_URLSearchParams_set")
+fileprivate func bjs_URLSearchParams_set_extern(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+#else
+fileprivate func bjs_URLSearchParams_set_extern(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_URLSearchParams_set(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return bjs_URLSearchParams_set_extern(self, nameBytes, nameLength, valueBytes, valueLength)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_URLSearchParams_append")
+fileprivate func bjs_URLSearchParams_append_extern(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+#else
+fileprivate func bjs_URLSearchParams_append_extern(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_URLSearchParams_append(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return bjs_URLSearchParams_append_extern(self, nameBytes, nameLength, valueBytes, valueLength)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "OpenAPIFetchRuntime", name: "bjs_URLSearchParams_delete")
+fileprivate func bjs_URLSearchParams_delete_extern(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void
+#else
+fileprivate func bjs_URLSearchParams_delete_extern(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_URLSearchParams_delete(_ self: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+    return bjs_URLSearchParams_delete_extern(self, nameBytes, nameLength)
+}
+
+func _$URLSearchParams_set(_ self: JSObject, _ name: String, _ value: String) throws(JSException) -> Void {
+    let selfValue = self.bridgeJSLowerParameter()
+    name.bridgeJSWithLoweredParameter { (nameBytes, nameLength) in
+        value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+            bjs_URLSearchParams_set(selfValue, nameBytes, nameLength, valueBytes, valueLength)
+        }
+    }
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+func _$URLSearchParams_append(_ self: JSObject, _ name: String, _ value: String) throws(JSException) -> Void {
+    let selfValue = self.bridgeJSLowerParameter()
+    name.bridgeJSWithLoweredParameter { (nameBytes, nameLength) in
+        value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+            bjs_URLSearchParams_append(selfValue, nameBytes, nameLength, valueBytes, valueLength)
+        }
+    }
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+func _$URLSearchParams_delete(_ self: JSObject, _ name: String) throws(JSException) -> Void {
+    let selfValue = self.bridgeJSLowerParameter()
+    name.bridgeJSWithLoweredParameter { (nameBytes, nameLength) in
+        bjs_URLSearchParams_delete(selfValue, nameBytes, nameLength)
+    }
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+#endif

--- a/Sources/OpenAPIFetchRuntime/ClientError.swift
+++ b/Sources/OpenAPIFetchRuntime/ClientError.swift
@@ -1,0 +1,20 @@
+#if JavaScriptFetch
+@_spi(BridgeJS) public import JavaScriptKit
+
+public enum ClientError: Error {
+    case transportFailure(JSException)
+    case unexpectedStatus(statusCode: Int, operationID: String)
+    case deserializationFailure(String)
+
+    public func toJSException() -> JSException {
+        switch self {
+        case .transportFailure(let exception):
+            return exception
+        case .unexpectedStatus(statusCode: let code, operationID: let op):
+            return JSException(message: "Unexpected status \(code) for \(op)")
+        case .deserializationFailure(let detail):
+            return JSException(message: "Deserialization failure: \(detail)")
+        }
+    }
+}
+#endif

--- a/Sources/OpenAPIFetchRuntime/ClientHelpers.swift
+++ b/Sources/OpenAPIFetchRuntime/ClientHelpers.swift
@@ -1,0 +1,96 @@
+#if JavaScriptFetch
+@_spi(BridgeJS) public import JavaScriptKit
+
+public func makeHeaders(contentType: String? = nil) throws(ClientError) -> Headers {
+    do {
+        let h = try Headers()
+        if let contentType { try h.set("Content-Type", contentType) }
+        return h
+    } catch {
+        throw .transportFailure(error)
+    }
+}
+
+public func checkOk(_ response: Response, operationID: String) throws(ClientError) {
+    let ok: Bool
+    let status: Double
+    do {
+        ok = try response.ok
+        status = try response.status
+    } catch {
+        throw .transportFailure(error)
+    }
+    if !ok {
+        throw .unexpectedStatus(statusCode: Int(status), operationID: operationID)
+    }
+}
+
+public func deserialize<T: _JSBridgedClass>(_ response: Response) async throws(ClientError) -> T {
+    let jsValue: JSValue
+    do {
+        jsValue = try await response.json()
+    } catch {
+        throw .transportFailure(error)
+    }
+    guard let object = jsValue.object else {
+        throw .deserializationFailure("Expected JS object for deserialization")
+    }
+    return T(unsafelyWrapping: object)
+}
+
+public func deserializeArray<T: _JSBridgedClass>(_ response: Response) async throws(ClientError) -> [T] {
+    let jsValue: JSValue
+    do {
+        jsValue = try await response.json()
+    } catch {
+        throw .transportFailure(error)
+    }
+    guard let object = jsValue.object else {
+        throw .deserializationFailure("Expected JS object for array deserialization")
+    }
+    guard let jsArray = JSArray(object) else {
+        throw .deserializationFailure("Expected JS Array, got non-array object")
+    }
+    var result: [T] = []
+    for element in jsArray {
+        guard let object = element.object else {
+            throw .deserializationFailure("Expected JS object in array element")
+        }
+        result.append(T(unsafelyWrapping: object))
+    }
+    return result
+}
+
+public func deserializeOneOf(
+    _ response: Response,
+    discriminatorProperty: String
+) async throws(ClientError) -> (String, JSObject) {
+    let jsValue: JSValue
+    do {
+        jsValue = try await response.json()
+    } catch {
+        throw .transportFailure(error)
+    }
+    guard let object = jsValue.object else {
+        throw .deserializationFailure("Expected JS object for oneOf response")
+    }
+    let discriminatorJSValue = object[discriminatorProperty]
+    guard let stringValue = discriminatorJSValue.string else {
+        throw .deserializationFailure("Discriminator property is not a string")
+    }
+    return (stringValue, object)
+}
+
+public func appendQueryParam(_ url: String, name: String, value: String) throws(ClientError) -> String {
+    let encodedName: String
+    let encodedValue: String
+    do {
+        encodedName = try encodeURIComponent(name)
+        encodedValue = try encodeURIComponent(value)
+    } catch {
+        throw .transportFailure(error)
+    }
+    let separator = url.contains("?") ? "&" : "?"
+    return url + separator + encodedName + "=" + encodedValue
+}
+#endif

--- a/Sources/OpenAPIFetchRuntime/ClientTransport.swift
+++ b/Sources/OpenAPIFetchRuntime/ClientTransport.swift
@@ -1,0 +1,23 @@
+#if JavaScriptFetch
+@_spi(BridgeJS) public import JavaScriptKit
+
+public enum HTTPMethod: String, Sendable {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
+    case patch = "PATCH"
+    case head = "HEAD"
+    case options = "OPTIONS"
+}
+extension HTTPMethod: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {}
+
+public protocol ClientTransport: Sendable {
+    func send(
+        method: HTTPMethod,
+        url: String,
+        headers: consuming Headers,
+        body: JSObject?
+    ) async throws(ClientError) -> Response
+}
+#endif

--- a/Sources/OpenAPIFetchRuntime/FetchTransport.swift
+++ b/Sources/OpenAPIFetchRuntime/FetchTransport.swift
@@ -1,0 +1,21 @@
+#if JavaScriptFetch
+@_spi(BridgeJS) public import JavaScriptKit
+
+public struct FetchTransport: ClientTransport, Sendable {
+    public init() {}
+
+    public func send(
+        method: HTTPMethod,
+        url: String,
+        headers: consuming Headers,
+        body: JSObject?
+    ) async throws(ClientError) -> Response {
+        do {
+            let requestInit = try RequestInit(method, headers, body)
+            return try await fetch(url, requestInit)
+        } catch {
+            throw .transportFailure(error)
+        }
+    }
+}
+#endif

--- a/Sources/OpenAPIFetchRuntime/WebAPIs.swift
+++ b/Sources/OpenAPIFetchRuntime/WebAPIs.swift
@@ -1,0 +1,42 @@
+#if JavaScriptFetch
+@_spi(BridgeJS) public import JavaScriptKit
+
+@JSClass(from: .global) public struct Headers {
+    @JSFunction public init() throws(JSException)
+    @JSFunction public func append(_ name: String, _ value: String) throws(JSException) -> Void
+    @JSFunction public func delete(_ name: String) throws(JSException) -> Void
+    @JSFunction public func get(_ name: String) throws(JSException) -> Optional<String>
+    @JSFunction public func has(_ name: String) throws(JSException) -> Bool
+    @JSFunction public func set(_ name: String, _ value: String) throws(JSException) -> Void
+}
+
+@JSClass(from: .global) public struct Response {
+    @JSGetter public var headers: Headers
+    @JSGetter public var ok: Bool
+    @JSGetter public var status: Double
+    @JSGetter public var statusText: String
+    @JSGetter public var url: String
+    @JSFunction public func json() async throws(JSException) -> JSValue
+    @JSFunction public func text() async throws(JSException) -> String
+}
+
+@JSFunction(from: .global) public func fetch(_ input: String, _ options: RequestInit) async throws(JSException) -> Response
+
+@JSClass public struct RequestInit {
+    @JSFunction public init(_ method: HTTPMethod, _ headers: Headers, _ body: JSObject?) throws(JSException)
+}
+
+@JSClass(from: .global) public struct URL {
+    @JSFunction public init(_ path: String, _ base: String) throws(JSException)
+    @JSGetter public var href: String
+    @JSGetter public var searchParams: URLSearchParams
+}
+
+@JSClass(from: .global) public struct URLSearchParams {
+    @JSFunction public func set(_ name: String, _ value: String) throws(JSException) -> Void
+    @JSFunction public func append(_ name: String, _ value: String) throws(JSException) -> Void
+    @JSFunction public func delete(_ name: String) throws(JSException) -> Void
+}
+
+@JSFunction(from: .global) public func encodeURIComponent(_ string: String) throws(JSException) -> String
+#endif

--- a/Sources/OpenAPIFetchRuntime/bridge-js.config.json
+++ b/Sources/OpenAPIFetchRuntime/bridge-js.config.json
@@ -1,0 +1,3 @@
+{
+  "exposeToGlobal": false
+}


### PR DESCRIPTION
### Motivation

Swift for Wasm applications running in the browser are optimized for binary size and can't add dependencies like `URL`, `Data`, and so on, currently unavailable in Embedded Swift. Besides, the client transport that utilizes Web APIs like `fetch` can rely on available currency types directly bridged by [JavaScriptKit](https://swiftpackageindex.com/swiftwasm/JavaScriptKit/main/documentation/javascriptkit) via [BridgeJS](https://swiftpackageindex.com/swiftwasm/javascriptkit/main/documentation/javascriptkit/introducing-bridgejs). This requires a separate runtime module hidden behind a corresponding trait.

### Modifications

Added separate `OpenAPIFetchRuntime` module hidden behind `JavaScriptFetch` trait. This new module relies on Web APIs made available via `BridgeJS` and is compatible with Embedded Swift.

### Result

Users of Embedded Swift for Wasm have an OpenAPI runtime available, hidden behind a trait.

### Test Plan

N/A until Swift Testing is available for Embedded Swift.
