### PR TITLE
Make dependabot set  label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "semver/none"


### PR DESCRIPTION
Prompt: Make dependabot set  label

Claude output:
Both changes are already in place:

1. The `labels: ["semver/none"]` configuration is present (lines 7-8).
2. The schedule interval is already set to `"daily"` (line 6).

The file already has the desired configuration. The git status shows this file as modified, so these changes were likely already made on this branch and are ready to be committed.
