### PR TITLE
update .spi build to request 6.3 and extended HTML output

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,5 +1,8 @@
 version: 1
 builder:
   configs:
-    - documentation_targets:
+    - swift_version: '6.3'
+      documentation_targets:
         - OpenAPIRuntime
+      custom_documentation_parameters:
+        - '--experimental-transform-for-static-hosting-with-content'


### PR DESCRIPTION
This updates the instructions for Swift Package Index to explicitly use Swift 6.3 for the documentation build, as well as enabling the additional experimental feature `--experimental-transform-for-static-hosting-with-content`, which embeds HTML content to (hopefully) make it easier to get improved SEO results for the documentation content.