### PR TITLE
Fix order-dependent hashing in OpenAPIObjectContainer and OpenAPIValueContainer

### DIFF
--- a/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
+++ b/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
@@ -421,10 +421,16 @@ public struct OpenAPIObjectContainer: Codable, Hashable, Sendable {
 
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func hash(into hasher: inout Hasher) {
+        var commutativeHash = 0
         for (key, itemValue) in value {
-            hasher.combine(key)
-            hasher.combine(OpenAPIValueContainer(validatedValue: itemValue))
+            // Note that we use a copy of our own hasher here. This makes hash values
+            // dependent on its state, eliminating static collision patterns.
+            var elementHasher = hasher
+            elementHasher.combine(key)
+            elementHasher.combine(OpenAPIValueContainer(validatedValue: itemValue))
+            commutativeHash ^= elementHasher.finalize()
         }
+        hasher.combine(commutativeHash)
     }
 }
 

--- a/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
+++ b/Sources/OpenAPIRuntime/Base/OpenAPIValue.swift
@@ -281,9 +281,9 @@ public struct OpenAPIValueContainer: Codable, Hashable, Sendable {
         case let value as [(any Sendable)?]:
             for item in value { hasher.combine(OpenAPIValueContainer(validatedValue: item)) }
         case let value as [String: (any Sendable)?]:
-            for (key, itemValue) in value {
+            for key in value.keys.sorted() {
                 hasher.combine(key)
-                hasher.combine(OpenAPIValueContainer(validatedValue: itemValue))
+                hasher.combine(OpenAPIValueContainer(validatedValue: value[key]))
             }
         default: break
         }
@@ -421,16 +421,10 @@ public struct OpenAPIObjectContainer: Codable, Hashable, Sendable {
 
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func hash(into hasher: inout Hasher) {
-        var commutativeHash = 0
-        for (key, itemValue) in value {
-            // Note that we use a copy of our own hasher here. This makes hash values
-            // dependent on its state, eliminating static collision patterns.
-            var elementHasher = hasher
-            elementHasher.combine(key)
-            elementHasher.combine(OpenAPIValueContainer(validatedValue: itemValue))
-            commutativeHash ^= elementHasher.finalize()
+        for key in value.keys.sorted() {
+            hasher.combine(key)
+            hasher.combine(OpenAPIValueContainer(validatedValue: value[key]))
         }
-        hasher.combine(commutativeHash)
     }
 }
 

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -444,6 +444,17 @@ final class Test_OpenAPIValue: Test_Runtime {
             encodedData
         )
     }
+
+    func testHashing_objectOrderIndependence_success() throws {
+        let container1 = try OpenAPIObjectContainer(
+            unvalidatedValue: ["foo": 0, "bar": 1]
+        )
+        let container2 = try OpenAPIObjectContainer(
+            unvalidatedValue: ["bar": 1, "foo": 0]
+        )
+        XCTAssertEqual(container1, container2)
+        XCTAssertEqual(container1.hashValue, container2.hashValue)
+    }
 }
 
 struct MyAnyOf2<Value1: Codable & Hashable & Sendable, Value2: Codable & Hashable & Sendable>: Codable, Hashable,

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -455,6 +455,17 @@ final class Test_OpenAPIValue: Test_Runtime {
         XCTAssertEqual(container1, container2)
         XCTAssertEqual(container1.hashValue, container2.hashValue)
     }
+
+    func testHashing_containerOrderIndependence_success() throws {
+        let container1 = try OpenAPIValueContainer(
+            unvalidatedValue: ["foo": 0, "bar": 1]
+        )
+        let container2 = try OpenAPIValueContainer(
+            unvalidatedValue: ["bar": 1, "foo": 0]
+        )
+        XCTAssertEqual(container1, container2)
+        XCTAssertEqual(container1.hashValue, container2.hashValue)
+    }
 }
 
 struct MyAnyOf2<Value1: Codable & Hashable & Sendable, Value2: Codable & Hashable & Sendable>: Codable, Hashable,

--- a/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
+++ b/Tests/OpenAPIRuntimeTests/Base/Test_OpenAPIValue.swift
@@ -446,23 +446,15 @@ final class Test_OpenAPIValue: Test_Runtime {
     }
 
     func testHashing_objectOrderIndependence_success() throws {
-        let container1 = try OpenAPIObjectContainer(
-            unvalidatedValue: ["foo": 0, "bar": 1]
-        )
-        let container2 = try OpenAPIObjectContainer(
-            unvalidatedValue: ["bar": 1, "foo": 0]
-        )
+        let container1 = try OpenAPIObjectContainer(unvalidatedValue: ["foo": 0, "bar": 1])
+        let container2 = try OpenAPIObjectContainer(unvalidatedValue: ["bar": 1, "foo": 0])
         XCTAssertEqual(container1, container2)
         XCTAssertEqual(container1.hashValue, container2.hashValue)
     }
 
     func testHashing_containerOrderIndependence_success() throws {
-        let container1 = try OpenAPIValueContainer(
-            unvalidatedValue: ["foo": 0, "bar": 1]
-        )
-        let container2 = try OpenAPIValueContainer(
-            unvalidatedValue: ["bar": 1, "foo": 0]
-        )
+        let container1 = try OpenAPIValueContainer(unvalidatedValue: ["foo": 0, "bar": 1])
+        let container2 = try OpenAPIValueContainer(unvalidatedValue: ["bar": 1, "foo": 0])
         XCTAssertEqual(container1, container2)
         XCTAssertEqual(container1.hashValue, container2.hashValue)
     }


### PR DESCRIPTION
### Motivation

`OpenAPIObjectContainer` and OpenAPIValueContainer’s `hash(into:)` depends on dictionary iteration order. This can cause equal values to produce different hashes, violating Hashable requirements.

### Modifications

Updated `hash(into:)` to sort keys before hashing.

### Result

Equal objects are now guaranteed to produce same hash value.

### Test Plan

Added a regression test verifying hash stability.