### PR TITLE
Deduplicate package Swift settings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,13 +14,6 @@
 //===----------------------------------------------------------------------===//
 import PackageDescription
 
-// General Swift-settings for all targets.
-let swiftSettings: [SwiftSetting] = [
-    // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
-    // Require `any` for existential types.
-    .enableUpcomingFeature("ExistentialAny")
-]
-
 let package = Package(
     name: "swift-openapi-runtime",
     platforms: [
@@ -44,13 +37,11 @@ let package = Package(
             name: "OpenAPIRuntime",
             dependencies: [
                 .product(name: "HTTPTypes", package: "swift-http-types")
-            ],
-            swiftSettings: swiftSettings
+            ]
         ),
         .testTarget(
             name: "OpenAPIRuntimeTests",
-            dependencies: ["OpenAPIRuntime"],
-            swiftSettings: swiftSettings
+            dependencies: ["OpenAPIRuntime"]
         ),
     ]
 )


### PR DESCRIPTION
## Summary
- remove the initial per-target swiftSettings assignment from Package.swift
- rely on the existing package target loop to apply ExistentialAny, MemberImportVisibility, and InternalImportsByDefault once to every target

## Validation
- ran git diff --check
- verified Package.swift has a single ExistentialAny setting application path

Note: I could not run SwiftPM tests in this environment because Swift/Xcode is not installed on the Windows host.