### PR TITLE
Redact sensitive values in error descriptions

### DIFF
--- a/Sources/OpenAPIRuntime/Interface/CurrencyTypes.swift
+++ b/Sources/OpenAPIRuntime/Interface/CurrencyTypes.swift
@@ -74,14 +74,78 @@ extension ServerRequestMetadata: CustomStringConvertible {
 }
 
 extension HTTPFields: PrettyStringConvertible {
+    private static var sensitiveHeaderNames: Set<String> {
+        [
+            "authorization",
+            "proxy-authorization",
+            "cookie",
+            "set-cookie",
+            "x-api-key",
+            "api-key",
+            "x-auth-token",
+            "x-csrf-token",
+            "x-xsrf-token",
+        ]
+    }
+
+    private static func shouldRedactHeader(named name: String) -> Bool {
+        let lowercasedName = name.lowercased()
+        return sensitiveHeaderNames.contains(lowercasedName) || lowercasedName.contains("token")
+            || lowercasedName.contains("secret")
+    }
+
     var prettyDescription: String {
-        sorted(by: { $0.name.canonicalName < $1.name.canonicalName }).map { "\($0.name.canonicalName): \($0.value)" }
-            .joined(separator: "; ")
+        sorted(by: { $0.name.canonicalName < $1.name.canonicalName }).map {
+            let name = $0.name.canonicalName
+            let value = Self.shouldRedactHeader(named: name) ? "<redacted>" : $0.value
+            return "\(name): \(value)"
+        }.joined(separator: "; ")
     }
 }
 
 extension HTTPRequest: PrettyStringConvertible {
-    var prettyDescription: String { "\(method.rawValue) \(path ?? "<nil>") [\(headerFields.prettyDescription)]" }
+    private static var sensitiveQueryItemNames: Set<String> {
+        [
+            "access_token",
+            "api_key",
+            "apikey",
+            "auth",
+            "authorization",
+            "code",
+            "id_token",
+            "password",
+            "refresh_token",
+            "secret",
+            "token",
+        ]
+    }
+
+    private static func shouldRedactQueryItem(named name: String) -> Bool {
+        let lowercasedName = name.lowercased()
+        return sensitiveQueryItemNames.contains(lowercasedName) || lowercasedName.contains("token")
+            || lowercasedName.contains("secret")
+    }
+
+    private static func redactedPath(_ path: String?) -> String {
+        guard let path else { return "<nil>" }
+        guard let queryStart = path.firstIndex(of: "?") else { return path }
+
+        let prefix = path[..<queryStart]
+        let queryAndFragment = path[path.index(after: queryStart)...]
+        let fragmentStart = queryAndFragment.firstIndex(of: "#")
+        let query = fragmentStart.map { queryAndFragment[..<$0] } ?? queryAndFragment[...]
+        let fragment = fragmentStart.map { queryAndFragment[$0...] } ?? ""
+
+        let redactedQuery = query.split(separator: "&", omittingEmptySubsequences: false).map { item -> String in
+            let parts = item.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard let name = parts.first, shouldRedactQueryItem(named: String(name)) else { return String(item) }
+            return "\(name)=<redacted>"
+        }.joined(separator: "&")
+
+        return "\(prefix)?\(redactedQuery)\(fragment)"
+    }
+
+    var prettyDescription: String { "\(method.rawValue) \(Self.redactedPath(path)) [\(headerFields.prettyDescription)]" }
 }
 
 extension HTTPResponse: PrettyStringConvertible {

--- a/Tests/OpenAPIRuntimeTests/Errors/Test_ClientError.swift
+++ b/Tests/OpenAPIRuntimeTests/Errors/Test_ClientError.swift
@@ -40,4 +40,33 @@ final class Test_ServerError: XCTestCase {
             "Server encountered an error handling the operation \"op\", caused by \"User handler threw an error.\", underlying error: Just description."
         )
     }
+
+    func testPrintingRedactsSensitiveRequestValues() throws {
+        let upstreamError = RuntimeError.handlerFailed(PrintableError())
+        let error: any Error = ServerError(
+            operationID: "op",
+            request: .init(
+                soar_path: "/test?token=request-token&name=jane",
+                method: .get,
+                headerFields: [
+                    .init("Cookie")!: "session=request-secret",
+                    .init("X-Trace-ID")!: "trace-id",
+                ]
+            ),
+            requestBody: nil,
+            requestMetadata: .init(),
+            causeDescription: upstreamError.prettyDescription,
+            underlyingError: upstreamError.underlyingError ?? upstreamError,
+            httpStatus: .internalServerError,
+            httpHeaderFields: [:],
+            httpBody: nil
+        )
+
+        let description = "\(error)"
+        XCTAssertFalse(description.contains("request-token"))
+        XCTAssertFalse(description.contains("request-secret"))
+        XCTAssertTrue(description.contains("token=<redacted>"))
+        XCTAssertTrue(description.contains("cookie: <redacted>"))
+        XCTAssertTrue(description.contains("x-trace-id: trace-id"))
+    }
 }

--- a/Tests/OpenAPIRuntimeTests/Errors/Test_ServerError.swift
+++ b/Tests/OpenAPIRuntimeTests/Errors/Test_ServerError.swift
@@ -35,4 +35,39 @@ final class Test_ClientError: XCTestCase {
             "Client encountered an error invoking the operation \"op\", caused by \"Transport threw an error.\", underlying error: Just description."
         )
     }
+
+    func testPrintingRedactsSensitiveRequestAndResponseValues() throws {
+        let upstreamError = RuntimeError.transportFailed(PrintableError())
+        let error: any Error = ClientError(
+            operationID: "op",
+            operationInput: "test",
+            request: .init(
+                soar_path: "/test?access_token=request-token&name=jane",
+                method: .get,
+                headerFields: [
+                    .init("Authorization")!: "Bearer request-secret",
+                    .init("X-Trace-ID")!: "trace-id",
+                ]
+            ),
+            response: .init(
+                status: .ok,
+                headerFields: [
+                    .init("Set-Cookie")!: "session=response-secret",
+                    .init("X-Request-ID")!: "request-id",
+                ]
+            ),
+            causeDescription: upstreamError.prettyDescription,
+            underlyingError: upstreamError.underlyingError ?? upstreamError
+        )
+
+        let description = "\(error)"
+        XCTAssertFalse(description.contains("request-token"))
+        XCTAssertFalse(description.contains("request-secret"))
+        XCTAssertFalse(description.contains("response-secret"))
+        XCTAssertTrue(description.contains("access_token=<redacted>"))
+        XCTAssertTrue(description.contains("authorization: <redacted>"))
+        XCTAssertTrue(description.contains("set-cookie: <redacted>"))
+        XCTAssertTrue(description.contains("x-trace-id: trace-id"))
+        XCTAssertTrue(description.contains("x-request-id: request-id"))
+    }
 }


### PR DESCRIPTION
## Summary
- redact sensitive HTTP header values when formatting runtime error descriptions
- redact common sensitive query parameters from request paths in formatted error descriptions
- add regression coverage for ClientError and ServerError descriptions

## Why
ClientError and ServerError include request/response metadata in their printable descriptions. Those descriptions can be logged by applications, and currently include raw header values such as Authorization, Cookie, and Set-Cookie, as well as query-string tokens. Redacting those values keeps the diagnostics useful while reducing accidental credential leakage.

## Testing
Not run locally because this environment is Windows and does not have Swift/Xcode installed. A macOS GitHub Actions validation run will be triggered on the fork branch.