### PR TITLE
Reject malformed accept header values

### DIFF
--- a/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
+++ b/Sources/OpenAPIRuntime/Conversion/Converter+Server.swift
@@ -56,10 +56,13 @@ extension Converter {
         guard let acceptHeader = headerFields[.accept] else { return }
 
         // Split with commas to get the individual values
-        let acceptValues = acceptHeader.split(separator: ",")
-            .map { value in
-                // Drop everything after the optional semicolon (q, extensions, ...)
-                value.split(separator: ";")[0].trimmingLeadingAndTrailingSpaces.lowercased()
+        let acceptValues = try acceptHeader.split(separator: ",")
+            .map { value -> String in
+                // Drop everything after the optional semicolon (q, extensions, ...), reject malformed.
+                guard let mediaRange = value.split(separator: ";").first else {
+                    throw RuntimeError.malformedAcceptHeader(String(value))
+                }
+                return mediaRange.trimmingLeadingAndTrailingSpaces.lowercased()
             }
         if acceptValues.isEmpty { return }
         guard let parsedSubstring = OpenAPIMIMEType(substring) else {

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
@@ -40,6 +40,11 @@ final class Test_ServerConverterExtensions: Test_Runtime {
         ]
         let multiple: HTTPFields = [.accept: "text/plain, application/json"]
         let params: HTTPFields = [.accept: "application/json; foo=bar"]
+        let semicolon: HTTPFields = [.accept: ";"]
+        let semicolons: HTTPFields = [.accept: ";;;;"]
+        let spacedSemicolon: HTTPFields = [.accept: " ; "]
+        let leadingSemicolon: HTTPFields = [.accept: "application/json,;"]
+        let garbage: HTTPFields = [.accept: "txet"]
         let cases: [(HTTPFields, String, Bool)] = [
             // No Accept header, any string validates successfully
             (emptyHeaders, "foobar", true),
@@ -64,6 +69,14 @@ final class Test_ServerConverterExtensions: Test_Runtime {
             // Params
             (params, "application/json; foo=bar", true), (params, "application/json; charset=utf-8; foo=bar", true),
             (params, "application/json", true), (params, "text/plain", false),
+            
+            // Rejects malformed expected content type
+            (wildcard, "txet", false),
+            
+            // Rejects malformed headers
+            (semicolon, "application/json", false), (semicolons, "application/json", false),
+            (spacedSemicolon, "application/json", false), (leadingSemicolon, "application/json", false),
+            (garbage, "application/json", false),
         ]
         for (headers, contentType, success) in cases {
             if success {

--- a/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
+++ b/Tests/OpenAPIRuntimeTests/Conversion/Test_Converter+Server.swift
@@ -69,14 +69,12 @@ final class Test_ServerConverterExtensions: Test_Runtime {
             // Params
             (params, "application/json; foo=bar", true), (params, "application/json; charset=utf-8; foo=bar", true),
             (params, "application/json", true), (params, "text/plain", false),
-            
-            // Rejects malformed expected content type
-            (wildcard, "txet", false),
-            
             // Rejects malformed headers
             (semicolon, "application/json", false), (semicolons, "application/json", false),
             (spacedSemicolon, "application/json", false), (leadingSemicolon, "application/json", false),
             (garbage, "application/json", false),
+            // Rejects malformed expected content type
+            (wildcard, "txet", false),
         ]
         for (headers, contentType, success) in cases {
             if success {


### PR DESCRIPTION
### Motivation

Swift OpenAPI Runtime crashes if receives a malformed accept header value consisting of just ";".

### Modifications

- Throw if accept header value if malformed and only contains ";".
- Add malformed header values to tests.

### Result

Swift OpenAPI Runtime no longer crashes if receives a malformed accept header value consisting of just ";".

### Test Plan

Cover all the throws in `validateAcceptIfPresent`.