### PR TITLE
Strip newlines when parsing events

### DIFF
--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsEncoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsEncoding.swift
@@ -167,8 +167,15 @@ extension ServerSentEventsSerializationSequence.Iterator {
                         buffer.append(contentsOf: value.utf8)
                         buffer.append(ASCII.lf)
                     }
-                    if let id = value.id { encodeField(name: "id", value: id) }
-                    if let event = value.event { encodeField(name: "event", value: event) }
+                    // Field values must not contain any newline characters, as they're used to
+                    // delimit fields and events, so strip any that are present.
+                    func removingNewlines(_ value: some StringProtocol) -> String {
+                        value.replacingOccurrences(of: "\r\n", with: "")
+                            .replacingOccurrences(of: "\r", with: "")
+                            .replacingOccurrences(of: "\n", with: "")
+                    }
+                    if let id = value.id { encodeField(name: "id", value: removingNewlines(id)) }
+                    if let event = value.event { encodeField(name: "event", value: removingNewlines(event)) }
                     if let retry = value.retry { encodeField(name: "retry", value: String(retry)) }
                     if let data = value.data {
                         // Normalize the data section by replacing CRLF and CR with just LF.

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsEncoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsEncoding.swift
@@ -167,7 +167,7 @@ extension ServerSentEventsSerializationSequence.Iterator {
                         buffer.append(contentsOf: value.utf8)
                         buffer.append(ASCII.lf)
                     }
-                    // Field values must not contain any newline characters, as they're used to
+                    // `id` and `event` values must not contain any newline characters, as they're used to
                     // delimit fields and events, so strip any that are present.
                     func removingNewlines(_ value: some StringProtocol) -> String {
                         value.replacingOccurrences(of: "\r\n", with: "").replacingOccurrences(of: "\r", with: "")

--- a/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsEncoding.swift
+++ b/Sources/OpenAPIRuntime/EventStreams/ServerSentEventsEncoding.swift
@@ -170,8 +170,7 @@ extension ServerSentEventsSerializationSequence.Iterator {
                     // Field values must not contain any newline characters, as they're used to
                     // delimit fields and events, so strip any that are present.
                     func removingNewlines(_ value: some StringProtocol) -> String {
-                        value.replacingOccurrences(of: "\r\n", with: "")
-                            .replacingOccurrences(of: "\r", with: "")
+                        value.replacingOccurrences(of: "\r\n", with: "").replacingOccurrences(of: "\r", with: "")
                             .replacingOccurrences(of: "\n", with: "")
                     }
                     if let id = value.id { encodeField(name: "id", value: removingNewlines(id)) }

--- a/Tests/OpenAPIRuntimeTests/EventStreams/Test_ServerSentEventsEncoding.swift
+++ b/Tests/OpenAPIRuntimeTests/EventStreams/Test_ServerSentEventsEncoding.swift
@@ -77,6 +77,20 @@ final class Test_ServerSentEventsEncoding: Test_Runtime {
                 """#
         )
     }
+    func testIdAndEventStripNewlines() async throws {
+        // The id and event fields must not contain newlines, as they would otherwise be
+        // misinterpreted as the start of another field.
+        try await _test(
+            input: [.init(id: "123\r\n456", event: "custom\nEvent\r", data: "hello")],
+            output: #"""
+                id: 123456
+                event: customEvent
+                data: hello
+
+
+                """#
+        )
+    }
     func _testJSONData<JSONType: Encodable & Hashable & Sendable>(
         input: [ServerSentEventWithJSONData<JSONType>],
         output: String,


### PR DESCRIPTION
### Motivation

The `id` and `event` fields aren't normalized the same way `data` already is, so they could end up split across multiple lines.

### Modifications

Strip newlines from `id` and `event`.

### Result

`id` and `event` each is serialized into a single line.

### Test Plan

Unit test.